### PR TITLE
Fix two problems with writing data to disk

### DIFF
--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -473,9 +473,12 @@ void UsbCapture::runDiskBuffers(void)
 
                 // Increment the statistics
                 numberOfDiskBuffersWritten++;
-            } else {
+            } else if (!captureComplete) {
                 // Sleep the thread for 100 uS to keep the CPU usage down
                 usleep(100);
+
+                // Then try the same buffer again, so we don't skip any
+                diskBufferNumber--;
             }
 
             // Check for transfer failure before continuing...

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -71,6 +71,7 @@ protected:
 private:
     qint32 numberOfDiskBuffersWritten;
     void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber, bool isTestData);
+    void writeConversionBuffer(QFile *outputFile, qint32 numBytes);
 
     void allocateDiskBuffers(void);
     void freeDiskBuffers(void);


### PR DESCRIPTION
The first fixes a race condition that results in buffers being written in the wrong order - I'm fairly sure I haven't seen this happen in real captures, but it's easy to provoke by extending the delay.

The second adds error checking when writing to and closing the output file.