### PR TITLE
Make DomesdayDuplicator tools work with Qt 6

### DIFF
--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -42,10 +42,10 @@ AdvancedNamingDialog::AdvancedNamingDialog(QWidget *parent) :
     ui->notesCheckBox->setChecked(false);
 
     // Set line edit validation to A-Z, a-z, 0-9 and space, minus and underscore
-    ui->discTitleLineEdit->setValidator(new QRegExpValidator(
-                                            QRegExp("^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$"), this ));
-    ui->notesLineEdit->setValidator(new QRegExpValidator(
-                                        QRegExp("^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$"), this ));
+    ui->discTitleLineEdit->setValidator(new QRegularExpressionValidator(
+                                            QRegularExpression("^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$"), this ));
+    ui->notesLineEdit->setValidator(new QRegularExpressionValidator(
+                                        QRegularExpression("^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$"), this ));
 
     updateGui();
 }

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
@@ -29,7 +29,7 @@
 #define ADVANCEDNAMINGDIALOG_H
 
 #include <QDialog>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <QDate>
 
 namespace Ui {

--- a/Linux-Application/DomesdayDuplicator/automaticcapturedialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/automaticcapturedialog.cpp
@@ -194,15 +194,8 @@ void AutomaticCaptureDialog::on_startClvCapturePushButton_clicked()
 {
     if (!captureInProgress) {
         // Create a formatted 7-character string of the time-code
-        QString startTimeCodeString;
-        startTimeCodeString.sprintf("%01d%02d%02d00", ui->startTimeTimeEdit->time().hour(),
-                         ui->startTimeTimeEdit->time().minute(),
-        ui->startTimeTimeEdit->time().second());
-
-        QString endTimeCodeString;
-        endTimeCodeString.sprintf("%01d%02d%02d00", ui->endTimeTimeEdit->time().hour(),
-                         ui->endTimeTimeEdit->time().minute(),
-        ui->endTimeTimeEdit->time().second());
+        QString startTimeCodeString = ui->startTimeTimeEdit->time().toString("Hmmss00");
+        QString endTimeCodeString = ui->endTimeTimeEdit->time().toString("Hmmss00");
 
         // Convert start and end time codes to integers
         qint32 startTimeCode = startTimeCodeString.toInt();

--- a/Linux-Application/DomesdayDuplicator/automaticcapturedialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/automaticcapturedialog.cpp
@@ -219,7 +219,7 @@ void AutomaticCaptureDialog::on_startClvCapturePushButton_clicked()
         } else if ((captureType == CaptureType::leadInCapture) && (endTimeCode == 0)) {
             // Show an error
             QMessageBox messageBox;
-            messageBox.warning(this, "Warning", tr("The end time be at least 1 second"));
+            messageBox.warning(this, "Warning", tr("The end time must be at least 1 second"));
             messageBox.setFixedSize(500, 200);
             return;
         }

--- a/Linux-Application/DomesdayDuplicator/playercommunication.cpp
+++ b/Linux-Application/DomesdayDuplicator/playercommunication.cpp
@@ -569,7 +569,7 @@ bool PlayerCommunication::setPositionFrame(qint32 address)
     QString response;
     QString command;
 
-    command.sprintf("FR%dSE\r", address);
+    command = QString("FR%1SE\r").arg(address);
     sendSerialCommand(command);
     response = getSerialResponse(L_TIMEOUT);
 
@@ -588,7 +588,7 @@ bool PlayerCommunication::setPositionTimeCode(qint32 address)
     QString response;
     QString command;
 
-    command.sprintf("FR%dSE\r", address);
+    command = QString("FR%1SE\r").arg(address);
     sendSerialCommand(command);
     response = getSerialResponse(L_TIMEOUT);
 
@@ -607,7 +607,7 @@ bool PlayerCommunication::setPositionChapter(qint32 address)
     QString response;
     QString command;
 
-    command.sprintf("CH%dSE\r", address);
+    command = QString("CH%1SE\r").arg(address);
     sendSerialCommand(command);
     response = getSerialResponse(L_TIMEOUT);
 
@@ -692,7 +692,7 @@ bool PlayerCommunication::setAudio(AudioState audioState)
     if (audioState == PlayerCommunication::AudioState::digitalCh2) parameter = 6;
     if (audioState == PlayerCommunication::AudioState::digitalStereo) parameter = 7;
 
-    command.sprintf("%dAD\r", parameter);
+    command = QString("%1AD\r").arg(parameter);
     sendSerialCommand(command);
     getSerialResponse(N_TIMEOUT);
 
@@ -736,7 +736,7 @@ bool PlayerCommunication::setSpeed(qint32 speed)
     QString response;
     QString command;
 
-    command.sprintf("%dSP\r", speed);
+    command = QString("%1SP\r").arg(speed);
     //qDebug() << "PlayerCommunication::setSpeed(): Sending command:" << command;
     sendSerialCommand(command);
     getSerialResponse(N_TIMEOUT);

--- a/Linux-Application/DomesdayDuplicator/playercontrol.cpp
+++ b/Linux-Application/DomesdayDuplicator/playercontrol.cpp
@@ -262,7 +262,7 @@ QString PlayerControl::getPlayerPositionInformation(void)
             QString secondString;
 
             // Get the full 7 character time-code string
-            timeCodeString.sprintf("%07d", timeCode);
+            timeCodeString = QString("%1").arg(timeCode, 7, 10, QChar('0'));
 
             // Split up the time-code
             hourString = timeCodeString.left(1);

--- a/Linux-Application/DomesdayDuplicator/playerremotedialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/playerremotedialog.cpp
@@ -118,8 +118,8 @@ void PlayerRemoteDialog::updateGui(void)
         QString secondString;
 
 
-        // Get the full 7 character time-code string
-        timeCodeString.sprintf("%05d", position.toInt());
+        // Pad the string out to 5 characters with zeros
+        timeCodeString = QString("%1").arg(position, 5, QChar('0'));
 
         // Split up the time-code
         hourString = timeCodeString.left(1);

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -278,7 +278,11 @@ void UsbCapture::run(void)
     allocateDiskBuffers();
 
     // Launch a thread for writing disk buffers to disk
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QFuture<void> future = QtConcurrent::run(this, &UsbCapture::runDiskBuffers);
+#else
+    QFuture<void> future = QtConcurrent::run(&UsbCapture::runDiskBuffers, this);
+#endif
     connect(this, SIGNAL(finished()), this, SLOT(deleteLater()));
 
     // Claim the required USB device interface for the transfer

--- a/Linux-Application/dddutil/sampledetails.cpp
+++ b/Linux-Application/dddutil/sampledetails.cpp
@@ -108,7 +108,7 @@ QString SampleDetails::getDurationString(void)
     qint64 duration = numberOfSamples / 40000000;
 
     // Return a QString in the format hh:mm:ss
-    return QDateTime::fromTime_t(static_cast<quint32>(duration)).toUTC().toString("hh:mm:ss");
+    return QDateTime::fromMSecsSinceEpoch(duration * 1000).toUTC().toString("hh:mm:ss");
 }
 
 // Get the input file format, returns true if 10-bit


### PR DESCRIPTION
Now that the ld-decode tools work with both Qt 5 and Qt 6, it'd be nice if the DDD tools did as well...

In most cases we just need to use a different API that Qt 5 already provides.

I've tested all of this except for the player control code, since I don't have a serial cable made up at the moment - I think it should work but it would be helpful if someone could try it out on real hardware.