### PR TITLE
Even more advanced naming

### DIFF
--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -89,10 +89,7 @@ QString AdvancedNamingDialog::getFileName(bool isTestData)
         }
 
         if (ui->discSideCheckBox->isChecked()) {
-            if (ui->sideOneRadioButton->isChecked()) fileName += "_side1";
-            if (ui->sideTwoRadioButton->isChecked()) fileName += "_side2";
-            if (ui->sideThreeRadioButton->isChecked()) fileName += "_side3";
-            if (ui->sideFourRadioButton->isChecked()) fileName += "_side4";
+            fileName += QString("_side%1").arg(ui->discSideSpinBox->value());
         }
 
         if (ui->notesCheckBox->isChecked()) {
@@ -144,15 +141,9 @@ void AdvancedNamingDialog::updateGui(void)
     }
 
     if (ui->discSideCheckBox->isChecked()) {
-        ui->sideOneRadioButton->setEnabled(true);
-        ui->sideTwoRadioButton->setEnabled(true);
-        ui->sideThreeRadioButton->setEnabled(true);
-        ui->sideFourRadioButton->setEnabled(true);
+        ui->discSideSpinBox->setEnabled(true);
     } else {
-        ui->sideOneRadioButton->setEnabled(false);
-        ui->sideTwoRadioButton->setEnabled(false);
-        ui->sideThreeRadioButton->setEnabled(false);
-        ui->sideFourRadioButton->setEnabled(false);
+        ui->discSideSpinBox->setEnabled(false);
     }
 
     if (ui->notesCheckBox->isChecked()) {

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -38,6 +38,7 @@ AdvancedNamingDialog::AdvancedNamingDialog(QWidget *parent) :
     ui->discTitleCheckBox->setChecked(false);
     ui->discTypeCheckBox->setChecked(false);
     ui->formatCheckBox->setChecked(false);
+    ui->audioCheckBox->setChecked(false);
     ui->discSideCheckBox->setChecked(false);
     ui->notesCheckBox->setChecked(false);
 
@@ -79,6 +80,12 @@ QString AdvancedNamingDialog::getFileName(bool isTestData)
         if (ui->formatCheckBox->isChecked()) {
             if (ui->formatNtscRadioButton->isChecked()) fileName += "_NTSC";
             if (ui->formatPalRadioButton->isChecked()) fileName += "_PAL";
+        }
+
+        if (ui->audioCheckBox->isChecked()) {
+            if (ui->audioAnalogueRadioButton->isChecked()) fileName += "_ANA";
+            if (ui->audioAc3RadioButton->isChecked()) fileName += "_AC3";
+            if (ui->audioDtsRadioButton->isChecked()) fileName += "_DTS";
         }
 
         if (ui->discSideCheckBox->isChecked()) {
@@ -124,6 +131,18 @@ void AdvancedNamingDialog::updateGui(void)
         ui->formatPalRadioButton->setEnabled(false);
     }
 
+    if (ui->audioCheckBox->isChecked()) {
+        ui->audioDefaultRadioButton->setEnabled(true);
+        ui->audioAnalogueRadioButton->setEnabled(true);
+        ui->audioAc3RadioButton->setEnabled(true);
+        ui->audioDtsRadioButton->setEnabled(true);
+    } else {
+        ui->audioDefaultRadioButton->setEnabled(false);
+        ui->audioAnalogueRadioButton->setEnabled(false);
+        ui->audioAc3RadioButton->setEnabled(false);
+        ui->audioDtsRadioButton->setEnabled(false);
+    }
+
     if (ui->discSideCheckBox->isChecked()) {
         ui->sideOneRadioButton->setEnabled(true);
         ui->sideTwoRadioButton->setEnabled(true);
@@ -154,6 +173,11 @@ void AdvancedNamingDialog::on_discTypeCheckBox_clicked()
 }
 
 void AdvancedNamingDialog::on_formatCheckBox_clicked()
+{
+    updateGui();
+}
+
+void AdvancedNamingDialog::on_audioCheckBox_clicked()
 {
     updateGui();
 }

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
@@ -50,6 +50,7 @@ private slots:
     void on_discTitleCheckBox_clicked();
     void on_discTypeCheckBox_clicked();
     void on_formatCheckBox_clicked();
+    void on_audioCheckBox_clicked();
     void on_discSideCheckBox_clicked();
     void on_notesCheckBox_clicked();
 

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
@@ -31,19 +31,6 @@
    <property name="title">
     <string>Advanced capture naming options:</string>
    </property>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>40</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Disc title:</string>
-    </property>
-   </widget>
    <widget class="QRadioButton" name="formatNtscRadioButton">
     <property name="geometry">
      <rect>
@@ -78,19 +65,6 @@
     <attribute name="buttonGroup">
      <string notr="true">formatButtonGroup</string>
     </attribute>
-   </widget>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>70</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Disc type:</string>
-    </property>
    </widget>
    <widget class="QRadioButton" name="typeCavRadioButton">
     <property name="geometry">
@@ -127,19 +101,6 @@
      <string notr="true">discTypeButtonGroup</string>
     </attribute>
    </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>100</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Format:</string>
-    </property>
-   </widget>
    <widget class="QLineEdit" name="discTitleLineEdit">
     <property name="enabled">
      <bool>true</bool>
@@ -153,30 +114,17 @@
      </rect>
     </property>
    </widget>
-   <widget class="QLabel" name="label_4">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>160</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Disc side:</string>
-    </property>
-   </widget>
    <widget class="QCheckBox" name="discTitleCheckBox">
     <property name="geometry">
      <rect>
       <x>10</x>
       <y>40</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string/>
+     <string>Disc title:</string>
     </property>
    </widget>
    <widget class="QCheckBox" name="discTypeCheckBox">
@@ -184,12 +132,12 @@
      <rect>
       <x>10</x>
       <y>70</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string/>
+     <string>Disc type:</string>
     </property>
    </widget>
    <widget class="QCheckBox" name="formatCheckBox">
@@ -197,12 +145,12 @@
      <rect>
       <x>10</x>
       <y>100</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string/>
+     <string>Format:</string>
     </property>
    </widget>
    <widget class="QCheckBox" name="discSideCheckBox">
@@ -210,25 +158,12 @@
      <rect>
       <x>10</x>
       <y>160</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>190</y>
-      <width>81</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Notes:</string>
+     <string>Disc side:</string>
     </property>
    </widget>
    <widget class="QLineEdit" name="notesLineEdit">
@@ -246,12 +181,12 @@
      <rect>
       <x>10</x>
       <y>190</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
      </rect>
     </property>
     <property name="text">
-     <string/>
+     <string>Notes:</string>
     </property>
    </widget>
    <widget class="QCheckBox" name="audioCheckBox">
@@ -259,21 +194,8 @@
      <rect>
       <x>10</x>
       <y>130</y>
-      <width>21</width>
+      <width>111</width>
       <height>22</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_6">
-    <property name="geometry">
-     <rect>
-      <x>40</x>
-      <y>130</y>
-      <width>81</width>
-      <height>21</height>
      </rect>
     </property>
     <property name="text">

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
@@ -166,73 +166,6 @@
      <string>Disc side:</string>
     </property>
    </widget>
-   <widget class="QRadioButton" name="sideOneRadioButton">
-    <property name="geometry">
-     <rect>
-      <x>130</x>
-      <y>160</y>
-      <width>41</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>1</string>
-    </property>
-    <property name="checked">
-     <bool>true</bool>
-    </property>
-    <attribute name="buttonGroup">
-     <string notr="true">discSideButtonGroup</string>
-    </attribute>
-   </widget>
-   <widget class="QRadioButton" name="sideTwoRadioButton">
-    <property name="geometry">
-     <rect>
-      <x>180</x>
-      <y>160</y>
-      <width>41</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>2</string>
-    </property>
-    <attribute name="buttonGroup">
-     <string notr="true">discSideButtonGroup</string>
-    </attribute>
-   </widget>
-   <widget class="QRadioButton" name="sideThreeRadioButton">
-    <property name="geometry">
-     <rect>
-      <x>230</x>
-      <y>160</y>
-      <width>41</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>3</string>
-    </property>
-    <attribute name="buttonGroup">
-     <string notr="true">discSideButtonGroup</string>
-    </attribute>
-   </widget>
-   <widget class="QRadioButton" name="sideFourRadioButton">
-    <property name="geometry">
-     <rect>
-      <x>280</x>
-      <y>160</y>
-      <width>41</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>4</string>
-    </property>
-    <attribute name="buttonGroup">
-     <string notr="true">discSideButtonGroup</string>
-    </attribute>
-   </widget>
    <widget class="QCheckBox" name="discTitleCheckBox">
     <property name="geometry">
      <rect>
@@ -414,6 +347,22 @@
      <string notr="true">audioButtonGroup</string>
     </attribute>
    </widget>
+   <widget class="QSpinBox" name="discSideSpinBox">
+    <property name="geometry">
+     <rect>
+      <x>130</x>
+      <y>160</y>
+      <width>61</width>
+      <height>23</height>
+     </rect>
+    </property>
+    <property name="minimum">
+     <number>1</number>
+    </property>
+    <property name="maximum">
+     <number>999</number>
+    </property>
+   </widget>
   </widget>
  </widget>
  <tabstops>
@@ -426,10 +375,6 @@
   <tabstop>formatNtscRadioButton</tabstop>
   <tabstop>formatPalRadioButton</tabstop>
   <tabstop>discSideCheckBox</tabstop>
-  <tabstop>sideOneRadioButton</tabstop>
-  <tabstop>sideTwoRadioButton</tabstop>
-  <tabstop>sideThreeRadioButton</tabstop>
-  <tabstop>sideFourRadioButton</tabstop>
   <tabstop>notesCheckBox</tabstop>
   <tabstop>notesLineEdit</tabstop>
  </tabstops>
@@ -438,7 +383,6 @@
  <buttongroups>
   <buttongroup name="discTypeButtonGroup"/>
   <buttongroup name="formatButtonGroup"/>
-  <buttongroup name="discSideButtonGroup"/>
   <buttongroup name="audioButtonGroup"/>
  </buttongroups>
 </ui>

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>220</height>
+    <height>250</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>500</width>
-    <height>220</height>
+    <height>250</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -25,7 +25,7 @@
      <x>10</x>
      <y>10</y>
      <width>481</width>
-     <height>201</height>
+     <height>231</height>
     </rect>
    </property>
    <property name="title">
@@ -157,7 +157,7 @@
     <property name="geometry">
      <rect>
       <x>40</x>
-      <y>130</y>
+      <y>160</y>
       <width>81</width>
       <height>21</height>
      </rect>
@@ -170,7 +170,7 @@
     <property name="geometry">
      <rect>
       <x>130</x>
-      <y>130</y>
+      <y>160</y>
       <width>41</width>
       <height>22</height>
      </rect>
@@ -189,7 +189,7 @@
     <property name="geometry">
      <rect>
       <x>180</x>
-      <y>130</y>
+      <y>160</y>
       <width>41</width>
       <height>22</height>
      </rect>
@@ -205,7 +205,7 @@
     <property name="geometry">
      <rect>
       <x>230</x>
-      <y>130</y>
+      <y>160</y>
       <width>41</width>
       <height>22</height>
      </rect>
@@ -221,7 +221,7 @@
     <property name="geometry">
      <rect>
       <x>280</x>
-      <y>130</y>
+      <y>160</y>
       <width>41</width>
       <height>22</height>
      </rect>
@@ -276,7 +276,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>130</y>
+      <y>160</y>
       <width>21</width>
       <height>22</height>
      </rect>
@@ -289,7 +289,7 @@
     <property name="geometry">
      <rect>
       <x>40</x>
-      <y>160</y>
+      <y>190</y>
       <width>81</width>
       <height>21</height>
      </rect>
@@ -302,7 +302,7 @@
     <property name="geometry">
      <rect>
       <x>130</x>
-      <y>160</y>
+      <y>190</y>
       <width>341</width>
       <height>21</height>
      </rect>
@@ -312,7 +312,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>160</y>
+      <y>190</y>
       <width>21</width>
       <height>22</height>
      </rect>
@@ -320,6 +320,99 @@
     <property name="text">
      <string/>
     </property>
+   </widget>
+   <widget class="QCheckBox" name="audioCheckBox">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>130</y>
+      <width>21</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_6">
+    <property name="geometry">
+     <rect>
+      <x>40</x>
+      <y>130</y>
+      <width>81</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Audio:</string>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="audioDefaultRadioButton">
+    <property name="geometry">
+     <rect>
+      <x>130</x>
+      <y>130</y>
+      <width>80</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Default</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+    <attribute name="buttonGroup">
+     <string notr="true">audioButtonGroup</string>
+    </attribute>
+   </widget>
+   <widget class="QRadioButton" name="audioAnalogueRadioButton">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>130</y>
+      <width>120</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Analogue only</string>
+    </property>
+    <attribute name="buttonGroup">
+     <string notr="true">audioButtonGroup</string>
+    </attribute>
+   </widget>
+   <widget class="QRadioButton" name="audioAc3RadioButton">
+    <property name="geometry">
+     <rect>
+      <x>340</x>
+      <y>130</y>
+      <width>70</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>AC3</string>
+    </property>
+    <attribute name="buttonGroup">
+     <string notr="true">audioButtonGroup</string>
+    </attribute>
+   </widget>
+   <widget class="QRadioButton" name="audioDtsRadioButton">
+    <property name="geometry">
+     <rect>
+      <x>410</x>
+      <y>130</y>
+      <width>70</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>DTS</string>
+    </property>
+    <attribute name="buttonGroup">
+     <string notr="true">audioButtonGroup</string>
+    </attribute>
    </widget>
   </widget>
  </widget>
@@ -346,5 +439,6 @@
   <buttongroup name="discTypeButtonGroup"/>
   <buttongroup name="formatButtonGroup"/>
   <buttongroup name="discSideButtonGroup"/>
+  <buttongroup name="audioButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Three improvements (hopefully) to the Advanced Naming dialogue:

Add audio types, which add `_ANA`, `_AC3` or `_DTS` to the filename. These tags match those used in lddb.com listings, as PAL/NTSC and CLV/CAV already do. I've called the no-label case "Default" on the grounds that it would mean digital-only for PAL and analogue/digital for NTSC.

Make the side number a spin box, so you can number bigger box sets automatically. 20-50 discs isn't uncommon in TV and anime series.

Make the checkbox labels clickable.