### PR TITLE
Enable test data checking in test mode

### DIFF
--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -653,15 +653,15 @@ void MainWindow::on_capturePushButton_clicked()
         // Start capture
 
         // Ensure that the test mode option matches the device configuration
-        qDebug() << "MainWindow::on_capturePushButton_clicked(): Setting device's test mode flag to" << ui->actionTest_mode->isChecked();
-        if (ui->actionTest_mode->isChecked()) usbDevice->sendConfigurationCommand(true);
-        else usbDevice->sendConfigurationCommand(false);
+        bool isTestMode = ui->actionTest_mode->isChecked();
+        qDebug() << "MainWindow::on_capturePushButton_clicked(): Setting device's test mode flag to" << isTestMode;
+        usbDevice->sendConfigurationCommand(isTestMode);
 
         // Construct the capture file path and name
 
         // Use the advanced naming dialogue to generate the capture file name
         captureFilename = configuration->getCaptureDirectory() +
-                advancedNamingDialog->getFileName(ui->actionTest_mode->isChecked());
+                advancedNamingDialog->getFileName(isTestMode);
 
         // Change the suffix depending on if the data is 10 or 16 bit
         if (configuration->getCaptureFormat() == Configuration::CaptureFormat::tenBitPacked) captureFilename += ".lds";
@@ -674,13 +674,13 @@ void MainWindow::on_capturePushButton_clicked()
 
         if (configuration->getCaptureFormat() == Configuration::CaptureFormat::tenBitPacked) {
             qDebug() << "MainWindow::on_capturePushButton_clicked(): Starting transfer - 10-bit packed";
-            usbDevice->startCapture(captureFilename, true, false);
+            usbDevice->startCapture(captureFilename, true, false, isTestMode);
         } else if (configuration->getCaptureFormat() == Configuration::CaptureFormat::tenBitCdPacked) {
             qDebug() << "MainWindow::on_capturePushButton_clicked(): Starting transfer - 10-bit packed 4:1 decimated";
-            usbDevice->startCapture(captureFilename, true, true);
+            usbDevice->startCapture(captureFilename, true, true, isTestMode);
         } else {
             qDebug() << "MainWindow::on_capturePushButton_clicked(): Starting transfer - 16-bit";
-            usbDevice->startCapture(captureFilename, false, false);
+            usbDevice->startCapture(captureFilename, false, false, isTestMode);
         }
 
         qDebug() << "MainWindow::on_capturePushButton_clicked(): Transfer started";

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -211,7 +211,7 @@ static void LIBUSB_CALL bulkTransferCallback(struct libusb_transfer *transfer)
 UsbCapture::UsbCapture(QObject *parent, libusb_context *libUsbContextParam,
                        libusb_device_handle *usbDeviceHandleParam,
                        QString filenameParam, bool isCaptureFormat10BitParam,
-                       bool isCaptureFormat10BitDecimatedParam) : QThread(parent)
+                       bool isCaptureFormat10BitDecimatedParam, bool isTestDataParam) : QThread(parent)
 {
     // Set the libUSB context
     libUsbContext = libUsbContextParam;
@@ -231,6 +231,7 @@ UsbCapture::UsbCapture(QObject *parent, libusb_context *libUsbContextParam,
     // Store the requested data format
     isCaptureFormat10Bit = isCaptureFormat10BitParam;
     isCaptureFormat10BitDecimated = isCaptureFormat10BitDecimatedParam;
+    isTestData = isTestDataParam;
 
     // Set the transfer abort flag
     transferAbort = false;
@@ -476,7 +477,7 @@ void UsbCapture::runDiskBuffers(void)
             if (isDiskBufferFull[diskBufferNumber] && !transferFailure) {
                 // Write the buffer
                 if (transferAbort) qDebug() << "UsbCapture::runDiskBuffers(): Transfer abort flagged, writing disk buffer" << diskBufferNumber;
-                writeBufferToDisk(&outputFile, diskBufferNumber, false);
+                writeBufferToDisk(&outputFile, diskBufferNumber);
 
                 // Mark it as empty
                 isDiskBufferFull[diskBufferNumber] = false;
@@ -502,7 +503,7 @@ void UsbCapture::runDiskBuffers(void)
             if (isDiskBufferFull[diskBufferNumber] && !transferFailure) {
                 // Write the buffer
                 qDebug() << "UsbCapture::runDiskBuffers(): Capture complete flagged, writing disk buffer" << diskBufferNumber;
-                writeBufferToDisk(&outputFile, diskBufferNumber, false);
+                writeBufferToDisk(&outputFile, diskBufferNumber);
 
                 // Mark it as empty
                 isDiskBufferFull[diskBufferNumber] = false;
@@ -526,7 +527,7 @@ void UsbCapture::runDiskBuffers(void)
 }
 
 // Write a disk buffer to disk
-void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber, bool isTestData)
+void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 {
     // Is this test data?
     if (isTestData) {

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -241,6 +241,9 @@ UsbCapture::UsbCapture(QObject *parent, libusb_context *libUsbContextParam,
     statistics.transferCount = 0;
     numberOfDiskBuffersWritten = 0;
 
+    // Initialise the test data sequence
+    savedTestDataValue = -1;
+
     // Clear the transfer failure flag
     transferFailure = false;
 
@@ -532,7 +535,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
     // Is this test data?
     if (isTestData) {
         // Verify the data
-        qint32 currentValue = -1;
+        qint32 currentValue = savedTestDataValue;
 
         for (qint32 pointer = 0; pointer < (TRANSFERSIZE * TRANSFERSPERDISKBUFFER); pointer += 2) {
             // Get the original 10-bit unsigned value from the disk data buffer
@@ -555,6 +558,9 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
                 }
             }
         }
+
+        qDebug() << "UsbCapture::writeBufferToDisk(): Verified test data OK - current value" << currentValue;
+        savedTestDataValue = currentValue;
     }
 
     // Write the data in 10 or 16 bit format

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -73,6 +73,7 @@ protected:
 
 private:
     qint32 numberOfDiskBuffersWritten;
+    qint32 savedTestDataValue;
     void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber);
     void writeConversionBuffer(QFile *outputFile, qint32 numBytes);
 

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -43,7 +43,8 @@ class UsbCapture : public QThread
 public:
     explicit UsbCapture(QObject *parent = nullptr, libusb_context *libUsbContextParam = nullptr,
                         libusb_device_handle *usbDeviceHandleParam = nullptr, QString filenameParam = nullptr,
-                        bool isCaptureFormat10BitParam = true, bool isCaptureFormat10BitDecimatedParam = false);
+                        bool isCaptureFormat10BitParam = true, bool isCaptureFormat10BitDecimatedParam = false,
+                        bool isTestData = false);
     ~UsbCapture() override;
 
     void startTransfer(void);
@@ -68,10 +69,11 @@ protected:
     QString filename;
     bool isCaptureFormat10Bit;
     bool isCaptureFormat10BitDecimated;
+    bool isTestData;
 
 private:
     qint32 numberOfDiskBuffersWritten;
-    void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber, bool isTestData);
+    void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber);
     void writeConversionBuffer(QFile *outputFile, qint32 numBytes);
 
     void allocateDiskBuffers(void);

--- a/Linux-Application/DomesdayDuplicator/usbdevice.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbdevice.cpp
@@ -363,7 +363,7 @@ bool UsbDevice::sendVendorSpecificCommand(quint8 command, quint16 value)
 }
 
 // Start capturing from the USB device
-void UsbDevice::startCapture(QString filename, bool isCaptureFormat10Bit, bool isCaptureFormat10BitDecimated)
+void UsbDevice::startCapture(QString filename, bool isCaptureFormat10Bit, bool isCaptureFormat10BitDecimated, bool isTestMode)
 {
     qDebug() << "UsbDevice::startCapture(): Starting capture";
 
@@ -375,7 +375,7 @@ void UsbDevice::startCapture(QString filename, bool isCaptureFormat10Bit, bool i
         // Create the capture object
         qDebug() << "UsbDevice::startCapture(): Creating the capture object";
         usbCapture = new UsbCapture(this, libUsbContext, usbDeviceHandle, filename,
-                                    isCaptureFormat10Bit, isCaptureFormat10BitDecimated);
+                                    isCaptureFormat10Bit, isCaptureFormat10BitDecimated, isTestMode);
 
         // Did we get a valid device handle?
         if (usbDeviceHandle != nullptr) {

--- a/Linux-Application/DomesdayDuplicator/usbdevice.h
+++ b/Linux-Application/DomesdayDuplicator/usbdevice.h
@@ -48,7 +48,7 @@ public:
     bool scanForDevice(void);
     void sendConfigurationCommand(bool testMode);
 
-    void startCapture(QString filename, bool isCaptureFormat10Bit, bool isCaptureFormat10BitDecimated);
+    void startCapture(QString filename, bool isCaptureFormat10Bit, bool isCaptureFormat10BitDecimated, bool isTestMode);
     void stopCapture(void);
     qint32 getNumberOfTransfers(void);
     qint32 getNumberOfDiskBuffersWritten(void);


### PR DESCRIPTION
The code to do this was present in UsbCapture already, but wasn't being enabled, and didn't check that the sequence continued correctly from one buffer to the next.

This should have no performance impact for regular captures, and minimal impact for test captures - it's just a single pass through the array so it should be cheap compared to actually writing the data to disk.