### PR TITLE
Run the capture thread with real-time priority

### DIFF
--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -27,6 +27,8 @@
 
 #include "usbcapture.h"
 
+#include <atomic>
+
 // Notes on transfer and disk buffering:
 //
 // TRANSFERSIZE: Each in-flight transfer returns 16 Kbytes * 16 (256 Kbytes)
@@ -53,32 +55,32 @@ struct transferUserDataStruct {
 };
 
 // Flag to indicate if disk buffer processing is running
-static volatile bool isDiskBufferProcessRunning;
+static std::atomic<bool> isDiskBufferProcessRunning;
 
 // Flag passed to mainwindow to notify of closefile
 static bool isOkToRename = false;
 
 // Global to monitor the number of in-flight transfers
-static volatile qint32 transfersInFlight = 0;
+static std::atomic<qint32> transfersInFlight(0);
 
 // Flag to cancel transfers in flight
-static volatile bool transferAbort = false;
+static std::atomic<bool> transferAbort(false);
 
 // Flag to show capture complete
-static volatile bool captureComplete = false;
+static std::atomic<bool> captureComplete(false);
 
 // Flag to show transfer failure
-static volatile bool transferFailure = false;
+static std::atomic<bool> transferFailure(false);
 
 // Private variables used to report statistics about the transfer process
 struct statisticsStruct {
-    qint32 transferCount;          // Number of successful transfers
+    std::atomic<qint32> transferCount;  // Number of successful transfers
 };
-static volatile statisticsStruct statistics;
+static statisticsStruct statistics;
 
 // Set up a pointer to the disk buffers and their full flags
 static unsigned char **diskBuffers = nullptr;
-static volatile bool isDiskBufferFull[NUMBEROFDISKBUFFERS];
+static std::atomic<bool> isDiskBufferFull[NUMBEROFDISKBUFFERS];
 
 // Set up a pointer to the conversion buffer
 static unsigned char *conversionBuffer;
@@ -87,7 +89,7 @@ static unsigned char *conversionBuffer;
 // before disk buffering starts.  It seems to be necessary to discard
 // the first set of in-flight transfers as the FX3 doesn't return
 // valid data until second set.
-static volatile qint32 flushCounter;
+static std::atomic<qint32> flushCounter;
 
 // Last error is a string used to communicate a failure reason to the GUI
 static QString lastError;

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -431,7 +431,7 @@ void UsbCapture::run(void)
 // Note: Using vectors would be neater, but they are just too slow
 void UsbCapture::allocateDiskBuffers(void)
 {
-    qDebug() << "UsbCapture::allocateDiskBuffers(): Allocating memory for disk buffers";
+    qDebug() << "UsbCapture::allocateDiskBuffers(): Allocating" << (1ULL * TRANSFERSIZE * TRANSFERSPERDISKBUFFER * NUMBEROFDISKBUFFERS) / (1024 * 1024) << "MiB memory for disk buffers";
     // Allocate the disk buffers
     diskBuffers = static_cast<unsigned char **>(calloc(NUMBEROFDISKBUFFERS, sizeof(unsigned char *)));
     if (diskBuffers != nullptr) {

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -29,6 +29,7 @@
 
 #include <atomic>
 #include <sched.h>
+#include <sys/mman.h>
 
 // Notes on transfer and disk buffering:
 //
@@ -435,6 +436,7 @@ void UsbCapture::allocateDiskBuffers(void)
     // Allocate the disk buffers
     diskBuffers = static_cast<unsigned char **>(calloc(NUMBEROFDISKBUFFERS, sizeof(unsigned char *)));
     if (diskBuffers != nullptr) {
+        bool tryMlock = true;
         for (quint32 bufferNumber = 0; bufferNumber < NUMBEROFDISKBUFFERS; bufferNumber++) {
 
             diskBuffers[bufferNumber] = static_cast<unsigned char *>(malloc(TRANSFERSIZE * TRANSFERSPERDISKBUFFER));
@@ -447,7 +449,15 @@ void UsbCapture::allocateDiskBuffers(void)
                 transferFailure = true;
                 break;
             }
+
+            // Lock the buffer into memory, preventing it from being paged out
+            if (tryMlock && mlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == -1) {
+                // Continue anyway, but print a warning
+                qInfo() << "UsbCapture::allocateDiskBuffers(): Unable to lock disk buffer into memory";
+                tryMlock = false;
+            }
         }
+        if (tryMlock) qDebug() << "UsbCapture::allocateDiskBuffers(): Locked disk buffers into memory";
     } else {
         // Memory allocation has failed
         qDebug() << "UsbCapture::allocateDiskBuffers(): Disk buffer array allocation failed!";
@@ -471,6 +481,9 @@ void UsbCapture::freeDiskBuffers(void)
     // Free up the allocated disk buffers
     if (diskBuffers != nullptr) {
         for (qint32 bufferNumber = 0; bufferNumber < NUMBEROFDISKBUFFERS; bufferNumber++) {
+            // Don't keep the buffer in RAM any more (silently ignoring failure)
+            (void) munlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+
             if (diskBuffers[bufferNumber] != nullptr) {
                 free(diskBuffers[bufferNumber]);
             }


### PR DESCRIPTION
This uses a couple of techniques common in Linux audio real-time programming: if possible, run the latency-sensitive capture thread with the `SCHED_RR` scheduling policy so it will preempt other userspace processes, and use `mlock` to ensure that the disk buffers stay in main memory rather than being paged out.

I tested this on my oldest USB3-capable machine (a Lenovo X220), and it significantly reduces the incidence of test-mode errors when the machine's under deliberately heavy load. On a current machine running a [PREEMPT-RT](https://wiki.linuxfoundation.org/realtime/preempt_rt_versions) kernel, I ran an 8h test-mode capture without errors while doing large compiles in the background.

This only affects the USB capture side of things - it would be worth thinking about increasing the number of disk buffers as well by default, since the current buffer is only about 3 seconds' worth of capture, and I expect most machines with USB3 can spare a couple of gigs of memory...