### PR TITLE
Add sequence numbers to sample values

### DIFF
--- a/DE0-NANO/DomesdayDuplicator/DomesdayDuplicator.v
+++ b/DE0-NANO/DomesdayDuplicator/DomesdayDuplicator.v
@@ -237,9 +237,9 @@ IPpllGenerator IPpllGenerator0 (
 );
 
 wire fx3_isReading;
-wire [9:0] dataGeneratorOut;
+wire [15:0] dataGeneratorOut;
 
-// Generate 10-bit data either from the ADC or the test data generator
+// Generate 16-bit data either from the ADC or the test data generator
 dataGenerator dataGenerator0 (
 	// Inputs
 	.nReset(fx3_nReset),				// Not reset
@@ -248,7 +248,7 @@ dataGenerator dataGenerator0 (
 	.testModeFlag(fx3_testMode),	// 1 = Test mode on
 	
 	// Outputs
-	.dataOut(dataGeneratorOut)		// 10-bit data out
+	.dataOut(dataGeneratorOut)		// 16-bit data out
 );
 
 // FIFO buffer
@@ -258,12 +258,12 @@ buffer buffer0 (
 	.writeClock(adc_clock),					// ADC clock
 	.readClock(fx3_clock),					// FX3 clock
 	.isReading(fx3_isReading),				// 1 = FX3 is reading data
-	.dataIn(dataGeneratorOut),				// 10-bit ADC data bus input
+	.dataIn(dataGeneratorOut),				// 16-bit ADC data bus input
 	
 	// Outputs
 	.bufferOverflow(fx3_bufferError),	// Set if a buffer overflow occurs
 	.dataAvailable(fx3_dataAvailable),	// Set if buffer contains at least 8192 words of data
-	.dataOut_16bit(fx3_databus)			// 16-bit data output
+	.dataOut(fx3_databus)					// 16-bit data output
 );
 
 // FX3 GPIF state-machine logic

--- a/DE0-NANO/DomesdayDuplicator/IPfifo.v
+++ b/DE0-NANO/DomesdayDuplicator/IPfifo.v
@@ -50,12 +50,12 @@ module IPfifo (
 	wrusedw);
 
 	input	  aclr;
-	input	[9:0]  data;
+	input	[15:0]  data;
 	input	  rdclk;
 	input	  rdreq;
 	input	  wrclk;
 	input	  wrreq;
-	output	[9:0]  q;
+	output	[15:0]  q;
 	output	  rdempty;
 	output	[13:0]  rdusedw;
 	output	  wrempty;
@@ -68,12 +68,12 @@ module IPfifo (
 // synopsys translate_on
 `endif
 
-	wire [9:0] sub_wire0;
+	wire [15:0] sub_wire0;
 	wire  sub_wire1;
 	wire [13:0] sub_wire2;
 	wire  sub_wire3;
 	wire [13:0] sub_wire4;
-	wire [9:0] q = sub_wire0[9:0];
+	wire [15:0] q = sub_wire0[15:0];
 	wire  rdempty = sub_wire1;
 	wire [13:0] rdusedw = sub_wire2[13:0];
 	wire  wrempty = sub_wire3;
@@ -100,7 +100,7 @@ module IPfifo (
 		dcfifo_component.lpm_numwords = 8192,
 		dcfifo_component.lpm_showahead = "ON",
 		dcfifo_component.lpm_type = "dcfifo",
-		dcfifo_component.lpm_width = 10,
+		dcfifo_component.lpm_width = 16,
 		dcfifo_component.lpm_widthu = 14,
 		dcfifo_component.overflow_checking = "ON",
 		dcfifo_component.rdsync_delaypipe = 5,
@@ -120,7 +120,7 @@ endmodule
 // Retrieval info: PRIVATE: AlmostEmptyThr NUMERIC "-1"
 // Retrieval info: PRIVATE: AlmostFull NUMERIC "0"
 // Retrieval info: PRIVATE: AlmostFullThr NUMERIC "-1"
-// Retrieval info: PRIVATE: CLOCKS_ARE_SYNCHRONIZED NUMERIC "1"
+// Retrieval info: PRIVATE: CLOCKS_ARE_SYNCHRONIZED NUMERIC "0"
 // Retrieval info: PRIVATE: Clock NUMERIC "4"
 // Retrieval info: PRIVATE: Depth NUMERIC "8192"
 // Retrieval info: PRIVATE: Empty NUMERIC "1"
@@ -135,11 +135,11 @@ endmodule
 // Retrieval info: PRIVATE: SYNTH_WRAPPER_GEN_POSTFIX STRING "0"
 // Retrieval info: PRIVATE: UNDERFLOW_CHECKING NUMERIC "0"
 // Retrieval info: PRIVATE: UsedW NUMERIC "1"
-// Retrieval info: PRIVATE: Width NUMERIC "10"
+// Retrieval info: PRIVATE: Width NUMERIC "16"
 // Retrieval info: PRIVATE: dc_aclr NUMERIC "1"
 // Retrieval info: PRIVATE: diff_widths NUMERIC "0"
 // Retrieval info: PRIVATE: msb_usedw NUMERIC "1"
-// Retrieval info: PRIVATE: output_width NUMERIC "10"
+// Retrieval info: PRIVATE: output_width NUMERIC "16"
 // Retrieval info: PRIVATE: rsEmpty NUMERIC "1"
 // Retrieval info: PRIVATE: rsFull NUMERIC "0"
 // Retrieval info: PRIVATE: rsUsedW NUMERIC "1"
@@ -154,7 +154,7 @@ endmodule
 // Retrieval info: CONSTANT: LPM_NUMWORDS NUMERIC "8192"
 // Retrieval info: CONSTANT: LPM_SHOWAHEAD STRING "ON"
 // Retrieval info: CONSTANT: LPM_TYPE STRING "dcfifo"
-// Retrieval info: CONSTANT: LPM_WIDTH NUMERIC "10"
+// Retrieval info: CONSTANT: LPM_WIDTH NUMERIC "16"
 // Retrieval info: CONSTANT: LPM_WIDTHU NUMERIC "14"
 // Retrieval info: CONSTANT: OVERFLOW_CHECKING STRING "ON"
 // Retrieval info: CONSTANT: RDSYNC_DELAYPIPE NUMERIC "5"
@@ -164,8 +164,8 @@ endmodule
 // Retrieval info: CONSTANT: WRITE_ACLR_SYNCH STRING "ON"
 // Retrieval info: CONSTANT: WRSYNC_DELAYPIPE NUMERIC "5"
 // Retrieval info: USED_PORT: aclr 0 0 0 0 INPUT GND "aclr"
-// Retrieval info: USED_PORT: data 0 0 10 0 INPUT NODEFVAL "data[9..0]"
-// Retrieval info: USED_PORT: q 0 0 10 0 OUTPUT NODEFVAL "q[9..0]"
+// Retrieval info: USED_PORT: data 0 0 16 0 INPUT NODEFVAL "data[15..0]"
+// Retrieval info: USED_PORT: q 0 0 16 0 OUTPUT NODEFVAL "q[15..0]"
 // Retrieval info: USED_PORT: rdclk 0 0 0 0 INPUT NODEFVAL "rdclk"
 // Retrieval info: USED_PORT: rdempty 0 0 0 0 OUTPUT NODEFVAL "rdempty"
 // Retrieval info: USED_PORT: rdreq 0 0 0 0 INPUT NODEFVAL "rdreq"
@@ -175,12 +175,12 @@ endmodule
 // Retrieval info: USED_PORT: wrreq 0 0 0 0 INPUT NODEFVAL "wrreq"
 // Retrieval info: USED_PORT: wrusedw 0 0 14 0 OUTPUT NODEFVAL "wrusedw[13..0]"
 // Retrieval info: CONNECT: @aclr 0 0 0 0 aclr 0 0 0 0
-// Retrieval info: CONNECT: @data 0 0 10 0 data 0 0 10 0
+// Retrieval info: CONNECT: @data 0 0 16 0 data 0 0 16 0
 // Retrieval info: CONNECT: @rdclk 0 0 0 0 rdclk 0 0 0 0
 // Retrieval info: CONNECT: @rdreq 0 0 0 0 rdreq 0 0 0 0
 // Retrieval info: CONNECT: @wrclk 0 0 0 0 wrclk 0 0 0 0
 // Retrieval info: CONNECT: @wrreq 0 0 0 0 wrreq 0 0 0 0
-// Retrieval info: CONNECT: q 0 0 10 0 @q 0 0 10 0
+// Retrieval info: CONNECT: q 0 0 16 0 @q 0 0 16 0
 // Retrieval info: CONNECT: rdempty 0 0 0 0 @rdempty 0 0 0 0
 // Retrieval info: CONNECT: rdusedw 0 0 14 0 @rdusedw 0 0 14 0
 // Retrieval info: CONNECT: wrempty 0 0 0 0 @wrempty 0 0 0 0

--- a/DE0-NANO/DomesdayDuplicator/IPfifo_bb.v
+++ b/DE0-NANO/DomesdayDuplicator/IPfifo_bb.v
@@ -45,12 +45,12 @@ module IPfifo (
 	wrusedw);
 
 	input	  aclr;
-	input	[9:0]  data;
+	input	[15:0]  data;
 	input	  rdclk;
 	input	  rdreq;
 	input	  wrclk;
 	input	  wrreq;
-	output	[9:0]  q;
+	output	[15:0]  q;
 	output	  rdempty;
 	output	[13:0]  rdusedw;
 	output	  wrempty;
@@ -72,7 +72,7 @@ endmodule
 // Retrieval info: PRIVATE: AlmostEmptyThr NUMERIC "-1"
 // Retrieval info: PRIVATE: AlmostFull NUMERIC "0"
 // Retrieval info: PRIVATE: AlmostFullThr NUMERIC "-1"
-// Retrieval info: PRIVATE: CLOCKS_ARE_SYNCHRONIZED NUMERIC "1"
+// Retrieval info: PRIVATE: CLOCKS_ARE_SYNCHRONIZED NUMERIC "0"
 // Retrieval info: PRIVATE: Clock NUMERIC "4"
 // Retrieval info: PRIVATE: Depth NUMERIC "8192"
 // Retrieval info: PRIVATE: Empty NUMERIC "1"
@@ -87,11 +87,11 @@ endmodule
 // Retrieval info: PRIVATE: SYNTH_WRAPPER_GEN_POSTFIX STRING "0"
 // Retrieval info: PRIVATE: UNDERFLOW_CHECKING NUMERIC "0"
 // Retrieval info: PRIVATE: UsedW NUMERIC "1"
-// Retrieval info: PRIVATE: Width NUMERIC "10"
+// Retrieval info: PRIVATE: Width NUMERIC "16"
 // Retrieval info: PRIVATE: dc_aclr NUMERIC "1"
 // Retrieval info: PRIVATE: diff_widths NUMERIC "0"
 // Retrieval info: PRIVATE: msb_usedw NUMERIC "1"
-// Retrieval info: PRIVATE: output_width NUMERIC "10"
+// Retrieval info: PRIVATE: output_width NUMERIC "16"
 // Retrieval info: PRIVATE: rsEmpty NUMERIC "1"
 // Retrieval info: PRIVATE: rsFull NUMERIC "0"
 // Retrieval info: PRIVATE: rsUsedW NUMERIC "1"
@@ -106,7 +106,7 @@ endmodule
 // Retrieval info: CONSTANT: LPM_NUMWORDS NUMERIC "8192"
 // Retrieval info: CONSTANT: LPM_SHOWAHEAD STRING "ON"
 // Retrieval info: CONSTANT: LPM_TYPE STRING "dcfifo"
-// Retrieval info: CONSTANT: LPM_WIDTH NUMERIC "10"
+// Retrieval info: CONSTANT: LPM_WIDTH NUMERIC "16"
 // Retrieval info: CONSTANT: LPM_WIDTHU NUMERIC "14"
 // Retrieval info: CONSTANT: OVERFLOW_CHECKING STRING "ON"
 // Retrieval info: CONSTANT: RDSYNC_DELAYPIPE NUMERIC "5"
@@ -116,8 +116,8 @@ endmodule
 // Retrieval info: CONSTANT: WRITE_ACLR_SYNCH STRING "ON"
 // Retrieval info: CONSTANT: WRSYNC_DELAYPIPE NUMERIC "5"
 // Retrieval info: USED_PORT: aclr 0 0 0 0 INPUT GND "aclr"
-// Retrieval info: USED_PORT: data 0 0 10 0 INPUT NODEFVAL "data[9..0]"
-// Retrieval info: USED_PORT: q 0 0 10 0 OUTPUT NODEFVAL "q[9..0]"
+// Retrieval info: USED_PORT: data 0 0 16 0 INPUT NODEFVAL "data[15..0]"
+// Retrieval info: USED_PORT: q 0 0 16 0 OUTPUT NODEFVAL "q[15..0]"
 // Retrieval info: USED_PORT: rdclk 0 0 0 0 INPUT NODEFVAL "rdclk"
 // Retrieval info: USED_PORT: rdempty 0 0 0 0 OUTPUT NODEFVAL "rdempty"
 // Retrieval info: USED_PORT: rdreq 0 0 0 0 INPUT NODEFVAL "rdreq"
@@ -127,12 +127,12 @@ endmodule
 // Retrieval info: USED_PORT: wrreq 0 0 0 0 INPUT NODEFVAL "wrreq"
 // Retrieval info: USED_PORT: wrusedw 0 0 14 0 OUTPUT NODEFVAL "wrusedw[13..0]"
 // Retrieval info: CONNECT: @aclr 0 0 0 0 aclr 0 0 0 0
-// Retrieval info: CONNECT: @data 0 0 10 0 data 0 0 10 0
+// Retrieval info: CONNECT: @data 0 0 16 0 data 0 0 16 0
 // Retrieval info: CONNECT: @rdclk 0 0 0 0 rdclk 0 0 0 0
 // Retrieval info: CONNECT: @rdreq 0 0 0 0 rdreq 0 0 0 0
 // Retrieval info: CONNECT: @wrclk 0 0 0 0 wrclk 0 0 0 0
 // Retrieval info: CONNECT: @wrreq 0 0 0 0 wrreq 0 0 0 0
-// Retrieval info: CONNECT: q 0 0 10 0 @q 0 0 10 0
+// Retrieval info: CONNECT: q 0 0 16 0 @q 0 0 16 0
 // Retrieval info: CONNECT: rdempty 0 0 0 0 @rdempty 0 0 0 0
 // Retrieval info: CONNECT: rdusedw 0 0 14 0 @rdusedw 0 0 14 0
 // Retrieval info: CONNECT: wrempty 0 0 0 0 @wrempty 0 0 0 0

--- a/DE0-NANO/DomesdayDuplicator/dataGenerator.v
+++ b/DE0-NANO/DomesdayDuplicator/dataGenerator.v
@@ -46,7 +46,7 @@ assign dataOut = testModeFlag ? testData : adcData;
 // negative edge of the clock
 //
 // Note: The test data is a repeating pattern of incrementing
-// values from 0 to 1023.
+// values from 0 to 1020.
 always @ (posedge clock, negedge nReset) begin
 	if (!nReset) begin
 		adcData <= 10'd0;
@@ -56,7 +56,10 @@ always @ (posedge clock, negedge nReset) begin
 		adcData <= adc_databus;
 		
 		// Test mode data generation
-		testData <= testData + 10'd1;
+		if (testData == 10'd1021 - 1)
+			testData <= 10'd0;
+		else
+			testData <= testData + 10'd1;
 	end
 end
 

--- a/DE0-NANO/DomesdayDuplicator/dataGenerator.v
+++ b/DE0-NANO/DomesdayDuplicator/dataGenerator.v
@@ -31,26 +31,38 @@ module dataGenerator (
 	input testModeFlag,
 	
 	// Outputs
-	output [9:0] dataOut
+	output [15:0] dataOut
 );
 
-// Register to store test and ADC data values
+// Register to store ADC data values
 reg [9:0] adcData;
+
+// Register to store test data values
 reg [9:0] testData;
+
+// Register to store the sequence number counter
+reg [21:0] sequenceCount;
+
+// The top 6 bits of the output are the sequence number
+assign dataOut[15:10] = sequenceCount[21:16];
 
 // If we are in test-mode use test data,
 // otherwise use the actual ADC data
-assign dataOut = testModeFlag ? testData : adcData;
+assign dataOut[9:0] = testModeFlag ? testData : adcData;
 
-// Read the ADC data and generate the test data on the
+// Read the ADC data and increment the counters on the
 // negative edge of the clock
 //
 // Note: The test data is a repeating pattern of incrementing
 // values from 0 to 1020.
+//
+// The sequence number counts from 0 to 62 repeatedly, with each
+// number being attached to 65536 samples.
 always @ (posedge clock, negedge nReset) begin
 	if (!nReset) begin
 		adcData <= 10'd0;
 		testData <= 10'd0;
+		sequenceCount <= 22'd0;
 	end else begin
 		// Read the ADC data
 		adcData <= adc_databus;
@@ -60,6 +72,12 @@ always @ (posedge clock, negedge nReset) begin
 			testData <= 10'd0;
 		else
 			testData <= testData + 10'd1;
+		
+		// Sequence number generation
+		if (sequenceCount == (6'd63 << 16) - 1)
+			sequenceCount <= 22'd0;
+		else
+			sequenceCount <= sequenceCount + 22'd1;
 	end
 end
 

--- a/DE0-NANO/DomesdayDuplicator/dataGenerator.v
+++ b/DE0-NANO/DomesdayDuplicator/dataGenerator.v
@@ -37,7 +37,6 @@ module dataGenerator (
 // Register to store test and ADC data values
 reg [9:0] adcData;
 reg [9:0] testData;
-wire [9:0] adc_databusRead;
 
 // If we are in test-mode use test data,
 // otherwise use the actual ADC data

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -575,9 +575,20 @@ void UsbCapture::runDiskBuffers(void)
     qDebug() << "UsbCapture::runDiskBuffers(): Thread stopped";
 }
 
+// Remove sequence numbers from a buffer
+void UsbCapture::checkBufferSequence(qint32 diskBufferNumber)
+{
+    // Remove the sequence numbers
+    for (qint32 pointer = 0; pointer < (TRANSFERSIZE * TRANSFERSPERDISKBUFFER); pointer += 2) {
+        diskBuffers[diskBufferNumber][pointer + 1] &= 3;
+    }
+}
+
 // Write a disk buffer to disk
 void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 {
+    checkBufferSequence(diskBufferNumber);
+
     // Is this test data?
     if (isTestData) {
         // Verify the data

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -582,26 +582,27 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
         // Verify the data
         qint32 currentValue = savedTestDataValue;
 
+        if (currentValue == -1) {
+            // Initialiase currentValue from the first value
+            currentValue = diskBuffers[diskBufferNumber][0] + (diskBuffers[diskBufferNumber][1] * 256);
+        }
+
         for (qint32 pointer = 0; pointer < (TRANSFERSIZE * TRANSFERSPERDISKBUFFER); pointer += 2) {
             // Get the original 10-bit unsigned value from the disk data buffer
             qint32 originalValue = diskBuffers[diskBufferNumber][pointer];
-            originalValue += diskBuffers[diskBufferNumber][pointer+1] * 256;
+            originalValue += diskBuffers[diskBufferNumber][pointer + 1] * 256;
 
-            if (currentValue == -1) {
-                // Initial data word
-                currentValue = originalValue;
-            } else {
-                currentValue++;
-                if (currentValue == 1024) currentValue = 0;
-
-                if (currentValue != originalValue) {
-                    // Data error
-                    qDebug() << "UsbCapture::writeBufferToDisk(): Data error! Expecting" << currentValue << "but got" << originalValue;
-                    lastError = tr("Test data verification error!");
-                    transferFailure = true;
-                    return;
-                }
+            if (currentValue != originalValue) {
+                // Data error
+                qDebug() << "UsbCapture::writeBufferToDisk(): Data error! Expecting" << currentValue << "but got" << originalValue;
+                lastError = tr("Test data verification error!");
+                transferFailure = true;
+                return;
             }
+
+            // Update currentValue
+            currentValue++;
+            if (currentValue == 1024) currentValue = 0;
         }
 
         savedTestDataValue = currentValue;

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -604,7 +604,6 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
             }
         }
 
-        qDebug() << "UsbCapture::writeBufferToDisk(): Verified test data OK - current value" << currentValue;
         savedTestDataValue = currentValue;
     }
 

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -74,6 +74,13 @@ protected:
 private:
     qint32 numberOfDiskBuffersWritten;
 
+    enum {
+        SEQUENCE_SYNC,
+        SEQUENCE_RUNNING,
+        SEQUENCE_DISABLED,
+        SEQUENCE_FAILED,
+    } sequenceState;
+    quint32 savedSequenceCounter;
     void checkBufferSequence(qint32 diskBufferNumber);
 
     qint32 savedTestDataValue;

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -73,6 +73,9 @@ protected:
 
 private:
     qint32 numberOfDiskBuffersWritten;
+
+    void checkBufferSequence(qint32 diskBufferNumber);
+
     qint32 savedTestDataValue;
     qint32 testDataMax;
     void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber);

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -74,6 +74,7 @@ protected:
 private:
     qint32 numberOfDiskBuffersWritten;
     qint32 savedTestDataValue;
+    qint32 testDataMax;
     void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber);
     void writeConversionBuffer(QFile *outputFile, qint32 numBytes);
 

--- a/Linux-Application/dddutil/analysetestdata.h
+++ b/Linux-Application/dddutil/analysetestdata.h
@@ -89,6 +89,7 @@ private:
     qint64 samplesToAnalyseTs;
 
     quint16 currentValue;
+    quint16 testDataMax;
     bool firstTest;
     bool testSuccessful;
 


### PR DESCRIPTION
These changes add a sequence number to the currently-unused top 6 bits of the sample values. The numbers are added immediately after sampling, then checked and removed by DomesdayDuplicator when the data is written to disk, so it can detect samples being dropped at any point in the transfer process.

The length of the test data sequence is also changed so that different transfers/buffers will contain different data in test mode, which makes it possible to detect some faults that couldn't be detected before (e.g. DomesdayDuplicator dropping or reordering buffers).

See below for some new text for the [FPGA firmware documentation](https://www.domesday86.com/?page_id=1070#dataGeneratorv), with rationale for the numbers chosen. I used [this script](https://github.com/atsampson/ld-decode-testsuite/blob/master/ddd/seqlength) to experiment with different sequence lengths (and [this test program](https://github.com/atsampson/ld-decode-testsuite/blob/master/ddd/ddd-freqcheck.cpp) might also be useful in the future as an end-to-end check).

DomesdayDuplicator and dddutil should still work correctly with existing FPGA firmware, although I haven't tested this extensively!

At present, DomesdayDuplicator stops the capture when missing samples are detected. It would be possible to make it insert an appropriate amount of padding and then continue instead - this probably isn't very useful at the moment, but if you were doing a capture that you only had one attempt at (say, a disintegrating videotape) then it would be worth implementing...

Fixes #107. Fixes #115.

## Documentation

The data generator module is responsible for generating data either from the ADC or (if in test mode) internally.  When in test mode the generator outputs a repeating sequence of 10-bit numbers, 0 to 1020 inclusive.

The data generator also inserts a sequence number into the top 6 bits of each sample, so that the DomesdayDuplicator application can detect missing samples. The sequence numbers count repeatedly from 0 to 62 inclusive, incrementing every 65536 samples.

Data from the ADC is read on the positive edge of the ADC clock and passed to the FIFO buffer.

The lengths of the test sequence (1021) and the sequence number sequence (63) were chosen in order to maximise the length of time before a USB transfer has the same contents as a previous transfer in test mode (about 210s). The number of samples per sequence number was chosen to allow a length of blocks of missing samples up to 0.1s to be detected correctly; experimentation on a machine with an early USB3 controller showed maximum dropouts of about 0.01s under artifically heavy CPU load, so this gives some additional margin.

(In versions of the firmware before June 2022, there were no sequence numbers, and the test sequence ran from 0 to 1023.)