### PR TITLE
Cmake build files

### DIFF
--- a/Linux-Application/DomesdayDuplicator/CMakeLists.txt
+++ b/Linux-Application/DomesdayDuplicator/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.16)
+project(DomesdayDuplicator VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
+
+# Set up AUTOMOC and some sensible defaults for runtime execution
+# When using Qt 6.3, you can replace the code block below with
+# qt_standard_project_setup()
+set(CMAKE_AUTOMOC ON)
+include(GNUInstallDirs)
+set(CMAKE_AUTOUIC ON)
+
+find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets SerialPort)
+find_package(LibUSB REQUIRED)
+
+qt_add_executable(DomesdayDuplicator MACOSX_BUNDLE
+    aboutdialog.cpp aboutdialog.h aboutdialog.ui
+    advancednamingdialog.cpp advancednamingdialog.h advancednamingdialog.ui
+    automaticcapturedialog.cpp automaticcapturedialog.h automaticcapturedialog.ui
+    configuration.cpp configuration.h
+    configurationdialog.cpp configurationdialog.h configurationdialog.ui
+    main.cpp
+    mainwindow.cpp mainwindow.h mainwindow.ui
+    playercommunication.cpp playercommunication.h
+    playercontrol.cpp playercontrol.h
+    playerremotedialog.cpp playerremotedialog.h playerremotedialog.ui
+    usbcapture.cpp usbcapture.h
+    usbdevice.cpp usbdevice.h
+)
+target_compile_definitions(DomesdayDuplicator PRIVATE
+    QT_DEPRECATED_WARNINGS
+)
+
+target_link_libraries(DomesdayDuplicator PRIVATE
+    Qt::Core
+    Qt::Gui
+    Qt::Widgets
+    Qt::SerialPort
+    ${LibUSB_LIBRARIES}
+)
+
+# Resources:
+set_source_files_properties("Graphics/Domesday Duplicator logo colour 250px.png"
+    PROPERTIES QT_RESOURCE_ALIAS "Domesday Duplicator logo"
+)
+set(resources_resource_files
+    "Graphics/Domesday Duplicator logo colour 150px.png"
+    "Graphics/Domesday Duplicator logo colour 250px.png"
+)
+
+qt_add_resources(DomesdayDuplicator "resources"
+    PREFIX
+        "/graphics/logo"
+    FILES
+        ${resources_resource_files}
+)
+set(resources1_resource_files
+    "Graphics/ApplicationIcon/DomesdayDuplicator_128x128.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_16x16.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_24x24.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_256x256.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_300x300.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_32x32.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_48x48.png"
+    "Graphics/ApplicationIcon/DomesdayDuplicator_64x64.png"
+)
+
+qt_add_resources(DomesdayDuplicator "resources1"
+    PREFIX
+        "/graphics/ApplicationIcon"
+    FILES
+        ${resources1_resource_files}
+)
+
+target_include_directories(DomesdayDuplicator PRIVATE
+    ${LibUSB_INCLUDE_DIRS}
+)
+
+
+if(WIN32)
+    target_compile_definitions(DomesdayDuplicator PRIVATE
+        NOMINMAX
+        QUSB_LIBRARY
+    )
+
+    target_link_libraries(DomesdayDuplicator PRIVATE
+        # TODO: Does this depend on compiler?
+        AdvAPI32
+    )
+endif()
+
+install(TARGETS DomesdayDuplicator
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Consider using qt_generate_deploy_app_script() for app deployment if
+# the project can use Qt 6.3. In that case rerun qmake2cmake with
+# --min-qt-version=6.3.

--- a/Linux-Application/DomesdayDuplicator/cmake_modules/FindLibUSB.cmake
+++ b/Linux-Application/DomesdayDuplicator/cmake_modules/FindLibUSB.cmake
@@ -1,0 +1,85 @@
+#Borrowed from https://github.com/OpenKinect/libfreenect2/blob/master/cmake_modules/FindLibUSB.cmake
+# Copyright (c) 2018 individual OpenKinect contributors (https://github.com/OpenKinect/libfreenect2/blob/master/CONTRIB)
+# File itself does not specify license, but project is dual GPL2/Apache
+
+
+# - Find libusb for portable USB support
+# 
+# If the LibUSB_ROOT environment variable
+# is defined, it will be used as base path.
+# The following standard variables get defined:
+#  LibUSB_FOUND:    true if LibUSB was found
+#  LibUSB_INCLUDE_DIR: the directory that contains the include file
+#  LibUSB_LIBRARIES:  the libraries
+
+IF(PKG_CONFIG_FOUND)
+  IF(DEPENDS_DIR) #Otherwise use System pkg-config path
+    SET(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${DEPENDS_DIR}/libusb/lib/pkgconfig")
+  ENDIF()
+  SET(MODULE "libusb-1.0")
+  IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    SET(MODULE "libusb-1.0>=1.0.20")
+  ENDIF()
+  IF(LibUSB_FIND_REQUIRED)
+    SET(LibUSB_REQUIRED "REQUIRED")
+  ENDIF()
+  PKG_CHECK_MODULES(LibUSB ${LibUSB_REQUIRED} ${MODULE})
+
+  FIND_LIBRARY(LibUSB_LIBRARY
+    NAMES ${LibUSB_LIBRARIES}
+    HINTS ${LibUSB_LIBRARY_DIRS}
+  )
+  SET(LibUSB_LIBRARIES ${LibUSB_LIBRARY})
+
+  RETURN()
+ENDIF()
+
+FIND_PATH(LibUSB_INCLUDE_DIRS
+  NAMES libusb.h
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    include
+    libusb
+    include/libusb-1.0
+)
+
+SET(LIBUSB_NAME libusb)
+
+FIND_LIBRARY(LibUSB_LIBRARIES
+  NAMES ${LIBUSB_NAME}-1.0
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    x64/Release/dll
+    x64/Debug/dll
+    Win32/Release/dll
+    Win32/Debug/dll
+    MS64
+    MS64/dll
+)
+
+IF(WIN32)
+FIND_FILE(LibUSB_DLL
+  ${LIBUSB_NAME}-1.0.dll
+  PATHS
+    "${DEPENDS_DIR}/libusb"
+    "${DEPENDS_DIR}/libusbx"
+    ENV LibUSB_ROOT
+  PATH_SUFFIXES
+    x64/Release/dll
+    x64/Debug/dll
+    Win32/Release/dll
+    Win32/Debug/dll
+    MS64
+    MS64/dll
+)
+ENDIF()
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUSB FOUND_VAR LibUSB_FOUND
+  REQUIRED_VARS LibUSB_LIBRARIES LibUSB_INCLUDE_DIRS)

--- a/Linux-Application/dddconv/CMakeLists.txt
+++ b/Linux-Application/dddconv/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(dddconv VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Set up AUTOMOC and some sensible defaults for runtime execution
+# When using Qt 6.3, you can replace the code block below with
+# qt_standard_project_setup()
+set(CMAKE_AUTOMOC ON)
+include(GNUInstallDirs)
+
+find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED Core)
+
+qt_add_executable(dddconv
+    dataconversion.cpp dataconversion.h
+    main.cpp
+)
+target_compile_definitions(dddconv PRIVATE
+    QT_DEPRECATED_WARNINGS
+)
+
+target_link_libraries(dddconv PRIVATE
+    Qt::Core
+)
+
+install(TARGETS dddconv
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Consider using qt_generate_deploy_app_script() for app deployment if
+# the project can use Qt 6.3. In that case rerun qmake2cmake with
+# --min-qt-version=6.3.

--- a/Linux-Application/dddutil/CMakeLists.txt
+++ b/Linux-Application/dddutil/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.16)
+project(dddutil VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Set up AUTOMOC and some sensible defaults for runtime execution
+# When using Qt 6.3, you can replace the code block below with
+# qt_standard_project_setup()
+set(CMAKE_AUTOMOC ON)
+include(GNUInstallDirs)
+set(CMAKE_AUTOUIC ON)
+
+find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets)
+
+qt_add_executable(dddutil WIN32 MACOSX_BUNDLE
+    about.cpp about.h about.ui
+    analysetestdata.cpp analysetestdata.h
+    fileconverter.cpp fileconverter.h
+    inputsample.cpp inputsample.h
+    main.cpp
+    mainwindow.cpp mainwindow.h mainwindow.ui
+    progressdialog.cpp progressdialog.h progressdialog.ui
+    sampledetails.cpp sampledetails.h
+)
+target_compile_definitions(dddutil PRIVATE
+    QT_DEPRECATED_WARNINGS
+)
+
+target_link_libraries(dddutil PRIVATE
+    Qt::Core
+    Qt::Gui
+    Qt::Widgets
+)
+
+install(TARGETS dddutil
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Consider using qt_generate_deploy_app_script() for app deployment if
+# the project can use Qt 6.3. In that case rerun qmake2cmake with
+# --min-qt-version=6.3.


### PR DESCRIPTION
Add cmake build files for easier setup on non-ubuntu

findlibusb borrowed from https://github.com/OpenKinect/libfreenect2 - there are other variants out there too so not sure what is most up to date, and whether that file has some specific license different from the project. 

mostly generated with qmake2cmake, though tweaked the linux-apllication to use a find script rather than the existing manual library linking to increase flexibility.

Will look at ld-decode tools next, though that will be more complex as there are multiple binaries.