### PR TITLE
Add Windows support to new page lock features

### DIFF
--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -29,7 +29,12 @@
 
 #include <atomic>
 #include <sched.h>
-#include <sys/mman.h>
+#ifdef __linux__
+    #include <sys/mman.h>
+#elif _WIN32
+    #include <memoryapi.h>
+#else
+#endif
 
 // Notes on transfer and disk buffering:
 //
@@ -311,11 +316,16 @@ void UsbCapture::run(void)
         return;
     }
 
+#ifdef __linux__
     // Save the current scheduling policy and parameters
     int oldSchedPolicy = sched_getscheduler(0);
     if (oldSchedPolicy == -1) oldSchedPolicy = SCHED_OTHER;
     struct sched_param oldSchedParam;
     if (sched_getparam(0, &oldSchedParam) == -1) oldSchedParam.sched_priority = 0;
+#elif _WIN32
+    // TODO: Implement pthread-win32 for scheduling on Windows
+#else
+#endif
 
     // Enable real-time scheduling for this thread
     int minSchedPriority = sched_get_priority_min(SCHED_RR);
@@ -397,10 +407,15 @@ void UsbCapture::run(void)
         libusb_handle_events_timeout(libUsbContext, &libusbHandleTimeout);
     }
 
+#ifdef __LINUX__
     // Return to the original scheduling policy while we're cleaning up
     if (sched_setscheduler(0, oldSchedPolicy, &oldSchedParam) == -1) {
         qDebug() << "UsbCapture::run(): Unable to restore original scheduling policy";
     }
+#elif _WIN32
+    // TODO: Implement pthread-win32 for scheduling on Windows
+#else
+#endif
 
     // Deallocate transfers
     qDebug() << "UsbCapture::run(): Transfer stopping - Freeing transfer buffers...";
@@ -457,7 +472,12 @@ void UsbCapture::allocateDiskBuffers(void)
             }
 
             // Lock the buffer into memory, preventing it from being paged out
+#ifdef __linux__
             if (tryMlock && mlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == -1) {
+#elif _WIN32
+            if (tryMlock && VirtualLock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == -1) {
+#else
+#endif
                 // Continue anyway, but print a warning
                 qInfo() << "UsbCapture::allocateDiskBuffers(): Unable to lock disk buffer into memory";
                 tryMlock = false;
@@ -488,7 +508,12 @@ void UsbCapture::freeDiskBuffers(void)
     if (diskBuffers != nullptr) {
         for (qint32 bufferNumber = 0; bufferNumber < NUMBEROFDISKBUFFERS; bufferNumber++) {
             // Don't keep the buffer in RAM any more (silently ignoring failure)
+#ifdef __linux__
             (void) munlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+#elif _WIN32
+            (void) VirtualUnlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+#else
+#endif
 
             if (diskBuffers[bufferNumber] != nullptr) {
                 free(diskBuffers[bufferNumber]);

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -470,7 +470,7 @@ void UsbCapture::allocateDiskBuffers(void)
 
             // Lock the buffer into memory, preventing it from being paged out
 #ifdef _WIN32
-            if (tryMlock && VirtualLock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == -1) {
+            if (tryMlock && VirtualLock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == 0) {
 #else
             if (tryMlock && mlock(diskBuffers[bufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER) == -1) {
 #endif


### PR DESCRIPTION
Include Windows' Virtual Memory libraries for their counterparts to mlock/munlock.  Remove scheduling for Windows-based builds.  Can be implemented later with a Windows port, such as pthread-win32