### PR TITLE
Improvements to the amplitude display

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         sudo apt-get update
         # libgl-dev is needed by QtGui, but not listed as a dependency
-        sudo apt-get install -y --no-install-recommends cmake libgl-dev qt6-base-dev libqt6serialport6-dev libusb-1.0-0-dev qt6-multimedia-dev
+        sudo apt-get install -y --no-install-recommends cmake libgl-dev qt6-base-dev libqt6serialport6-dev libusb-1.0-0-dev
 
     - name: Configure
       timeout-minutes: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QT_VERSION=5 .
 
     - name: Build
       timeout-minutes: 15
@@ -53,7 +53,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_QT_VERSION=6 .
 
     - name: Build
       timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd Linux-Application && cmake .
+      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 
     - name: Build
       timeout-minutes: 15
@@ -53,7 +53,7 @@ jobs:
 
     - name: Configure
       timeout-minutes: 5
-      run: cd Linux-Application && cmake .
+      run: cd Linux-Application && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 
     - name: Build
       timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,30 @@ on:
   release:
 
 jobs:
+  qt5:
+    name: Build with Qt 5
+    runs-on: ubuntu-20.04
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      timeout-minutes: 10
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends cmake qt5-default libqt5serialport5-dev libusb-1.0-0-dev
+
+    - name: Configure
+      timeout-minutes: 5
+      run: cd Linux-Application && cmake .
+
+    - name: Build
+      timeout-minutes: 15
+      run: make -C Linux-Application VERBOSE=1
+
+    - name: Install
+      timeout-minutes: 5
+      run: make -C Linux-Application DESTDIR=/tmp/staging install
 
   qt6:
     name: Build with Qt 6

--- a/Linux-Application/CMakeLists.txt
+++ b/Linux-Application/CMakeLists.txt
@@ -6,6 +6,14 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Options that can be specified with -D
+
+set(USE_QT_VERSION "" CACHE STRING
+    "Version of Qt to use (by default, try Qt 6 then Qt 5)"
+)
+
+# Check for dependencies
+
 # Set up AUTOMOC and some sensible defaults for runtime execution
 # When using Qt 6.3, you can replace the code block below with
 # qt_standard_project_setup()
@@ -13,7 +21,11 @@ set(CMAKE_AUTOMOC ON)
 include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
-find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
+set(QT_PACKAGE_NAMES Qt5 Qt6)
+if(USE_QT_VERSION)
+    set(QT_PACKAGE_NAMES Qt${USE_QT_VERSION})
+endif()
+find_package(QT NAMES ${QT_PACKAGE_NAMES} REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets SerialPort)
 find_package(LibUSB REQUIRED)
 

--- a/Linux-Application/CMakeLists.txt
+++ b/Linux-Application/CMakeLists.txt
@@ -3,6 +3,9 @@ project(DomesdayDuplicator VERSION 1.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set up AUTOMOC and some sensible defaults for runtime execution
 # When using Qt 6.3, you can replace the code block below with
 # qt_standard_project_setup()

--- a/Linux-Application/CMakeLists.txt
+++ b/Linux-Application/CMakeLists.txt
@@ -11,7 +11,7 @@ include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
 find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets SerialPort Multimedia)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets SerialPort)
 find_package(LibUSB REQUIRED)
 
 # For Qt < 5.15, emulate 5.15's Qt5CoreConfig.cmake, so we don't have to
@@ -21,7 +21,7 @@ if(QT_VERSION VERSION_LESS 5.15)
         qt5_add_resources("${outfiles}" ${ARGN})
         set("${outfiles}" "${${outfiles}}" PARENT_SCOPE)
     endfunction()
-    foreach(library Core Gui SerialPort Widgets Multimedia)
+    foreach(library Core Gui SerialPort Widgets)
         add_library(Qt::${library} INTERFACE IMPORTED)
         set_target_properties(Qt::${library} PROPERTIES
             INTERFACE_LINK_LIBRARIES "Qt5::${library}")

--- a/Linux-Application/DomesdayDuplicator/CMakeLists.txt
+++ b/Linux-Application/DomesdayDuplicator/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(DomesdayDuplicator PRIVATE
     Qt::Gui
     Qt::Widgets
     Qt::SerialPort
-    Qt::Multimedia
     ${LibUSB_LIBRARIES}
 )
 

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -25,21 +25,22 @@
 
 ************************************************************************/
 
+#include "amplitudemeasurement.h"
+
 #include <QtWidgets>
 #include <QtMultimedia>
 #include <QAudioBuffer>
-#include "usbcapture.h"
-#include "amplitudemeasurement.h"
 #include <QList>
 #include <QAudioDevice>
 #include <QAudioSource>
+#include "usbcapture.h"
 
 // Note that in signed 16 PCM, one disk buffer (64MB) is 838860 milliseconds
 
 static int plotpointcount = 0;
 qreal peak = 32767;
 // Fill array with zeroes and backfill as needed
-QList<double> rollingAmp({0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0});
+QList<double> rollingAmp({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
 // Initialize QCP graph
 AmplitudeMeasurement::AmplitudeMeasurement(QWidget *parent)
@@ -52,7 +53,7 @@ AmplitudeMeasurement::AmplitudeMeasurement(QWidget *parent)
     setBackground(QColor(240, 240, 240, 255));
     yAxis->setRange(QCPRange(-1, 1));
     axisRect()->setAutoMargins(QCP::msNone);
-    axisRect()->setMargins(QMargins(25,7,0,6));
+    axisRect()->setMargins(QMargins(25, 7, 0, 6));
     QFont yfont;
     yfont.setPointSize(6);
     yAxis->setTickLabelFont(yfont);
@@ -62,10 +63,12 @@ AmplitudeMeasurement::AmplitudeMeasurement(QWidget *parent)
 void AmplitudeMeasurement::plot()
 {
     QVector<double> x(samples.size());
-    for (int i=0; i<x.size(); i++)
+    for (int i = 0; i < x.size(); i++) {
         x[i] = i;
-    if (wavePlot->dataCount() >= 1027)
+    }
+    if (wavePlot->dataCount() >= 1027) {
         wavePlot->data()->clear();
+    }
     wavePlot->addData(x, samples);
     xAxis->setRange(QCPRange(0, samples.size()));
     replot();
@@ -74,7 +77,6 @@ void AmplitudeMeasurement::plot()
 //Fill the buffer with data
 void AmplitudeMeasurement::setBuffer()
 {
-
     QAudioFormat format;
     format.setSampleRate(40000);
     format.setChannelCount(1);
@@ -85,9 +87,10 @@ void AmplitudeMeasurement::setBuffer()
     const qint16 *data = ampliBuffer.constData<qint16>();
     int count = ampliBuffer.sampleCount();
 
-    for (int i=0; i<count; i++){
-        double val = data[i]/peak;
-        i=i+1000000;
+    for (int i = 0; i < count; i++) {
+        double val = data[i] / peak;
+        i += 1000000;
+
         plotpointcount++;
         if (plotpointcount >= 1028) {
             samples.removeFirst();
@@ -113,21 +116,21 @@ double AmplitudeMeasurement::getMeanAmplitude()
     const qint16 *ampliData = ampliBuffer.constData<qint16>();
     double ampliCount = ampliBuffer.sampleCount();
 
-    for (int i=0; i<ampliCount; i++){
+    for (int i = 0; i < ampliCount; i++){
         const double& data = ampliData[i];
-        avgVal = data/peak;
+        avgVal = data / peak;
         posSum += avgVal * avgVal;
     }
-    for (int i=0; i<19; i++) {
-        rollingAmp.move(i+1, i);
+    for (int i = 0; i < 19; i++) {
+        rollingAmp.move(i + 1, i);
     }
-    rollingAmp[19] = sqrt(posSum / (ampliCount/2));
-    for (int ra=0; ra<19; ra++) {
+    rollingAmp[19] = sqrt(posSum / (ampliCount / 2));
+    for (int ra = 0; ra < 19; ra++) {
         finalAmp += rollingAmp[ra];
     }
     if (rollingAmp.contains(0)) {
         return rollingAmp[19];
     } else {
-    return ((finalAmp)/20);
+        return finalAmp / 20;
     }
 }

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -1,3 +1,30 @@
+/************************************************************************
+
+    amplitudemeasurement.cpp
+
+    Capture application for the Domesday Duplicator
+    DomesdayDuplicator - LaserDisc RF sampler
+    Copyright (C) 2022 Matt Perry
+
+    This file is part of Domesday Duplicator.
+
+    Domesday Duplicator is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Email: simon.inns@gmail.com
+
+************************************************************************/
+
 #include <QtWidgets>
 #include <QtMultimedia>
 #include <QAudioBuffer>

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -36,10 +36,7 @@
 
 // Note that in signed 16 PCM, one disk buffer (64MB) is 838860 milliseconds
 
-QList<int> m_buffer;
-QVector<double> sample;
 static int plotpointcount = 0;
-int signalPeaks = 0;
 qreal peak = 32767;
 // Fill array with zeroes and backfill as needed
 QList<double> rollingAmp({0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0});

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
@@ -28,14 +28,8 @@
 #ifndef AMPLITUDEMEASUREMENT_H
 #define AMPLITUDEMEASUREMENT_H
 
-#include <QtCore/QIODevice>
-#include <QtCore/QPointF>
-#include <QtCore/QVector>
-#include <QThread>
-#include <QAudioBuffer>
-#include <QAudioSource>
-#include <QMediaDevices>
-#include <QAudioBuffer>
+#include <QVector>
+#include <vector>
 #include "qcustomplot.h"
 
 class AmplitudeMeasurement : public QCustomPlot
@@ -44,14 +38,15 @@ class AmplitudeMeasurement : public QCustomPlot
 
 public:
     AmplitudeMeasurement(QWidget *parent = Q_NULLPTR);
-    static double getMeanAmplitude();
+    double getMeanAmplitude();
 
 public slots:
-    void setBuffer();
-    void plot();
+    void updateBuffer();
+    void plotGraph();
 
 private:
-    QVector<double> samples;
+    std::vector<qint16> inputSamples;
+    QVector<double> graphXValues, graphYValues;
     QCPGraph *wavePlot;
 };
 

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
@@ -27,6 +27,7 @@
 
 #ifndef AMPLITUDEMEASUREMENT_H
 #define AMPLITUDEMEASUREMENT_H
+
 #include <QtCore/QIODevice>
 #include <QtCore/QPointF>
 #include <QtCore/QVector>
@@ -42,19 +43,16 @@ class AmplitudeMeasurement : public QCustomPlot
     Q_OBJECT
 
 public:
-
-   AmplitudeMeasurement(QWidget *parent = Q_NULLPTR);
-   static double getMeanAmplitude();
+    AmplitudeMeasurement(QWidget *parent = Q_NULLPTR);
+    static double getMeanAmplitude();
 
 public slots:
-   void setBuffer();
-   void plot();
+    void setBuffer();
+    void plot();
 
 private:
-   QVector<double> samples;
+    QVector<double> samples;
     QCPGraph *wavePlot;
 };
-
-
 
 #endif // AMPLITUDEMEASUREMENT_H

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
@@ -43,21 +43,16 @@ class AmplitudeMeasurement : public QCustomPlot
 
 public:
 
-   static const int availableSamples = 33554400;
-   static const int sampleCount = 2000;
-   qreal level() const { return level(); }
    AmplitudeMeasurement(QWidget *parent = Q_NULLPTR);
    static double getMeanAmplitude();
-   static QByteArray audioBuffer();
 
 public slots:
    void setBuffer();
    void plot();
 
 private:
-   qreal getPeakValue(const QAudioFormat& format);
    QVector<double> samples;
-   QCPGraph *wavePlot;
+    QCPGraph *wavePlot;
 };
 
 

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
@@ -1,3 +1,30 @@
+/************************************************************************
+
+    amplitudemeasurement.h
+
+    Capture application for the Domesday Duplicator
+    DomesdayDuplicator - LaserDisc RF sampler
+    Copyright (C) 2022 Matt Perry
+
+    This file is part of Domesday Duplicator.
+
+    Domesday Duplicator is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Email: simon.inns@gmail.com
+
+************************************************************************/
+
 #ifndef AMPLITUDEMEASUREMENT_H
 #define AMPLITUDEMEASUREMENT_H
 #include <QtCore/QIODevice>

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.h
@@ -29,6 +29,7 @@
 #define AMPLITUDEMEASUREMENT_H
 
 #include <QVector>
+#include <array>
 #include <vector>
 #include "qcustomplot.h"
 
@@ -47,6 +48,7 @@ public slots:
 private:
     std::vector<qint16> inputSamples;
     QVector<double> graphXValues, graphYValues;
+    std::array<double, 20> rollingAmp;
     QCPGraph *wavePlot;
 };
 

--- a/Linux-Application/DomesdayDuplicator/configuration.cpp
+++ b/Linux-Application/DomesdayDuplicator/configuration.cpp
@@ -53,10 +53,6 @@ Configuration::Configuration(QObject *parent) : QObject(parent)
     }
 }
 
-// Init variables for amplitude configuration
-bool processTextAmplitude = false;
-bool processGraphAmplitude = false;
-
 void Configuration::writeConfiguration(void)
 {
     // Write the valid configuration flag
@@ -327,7 +323,6 @@ void Configuration::setAmplitudeEnabled(bool amplitudeEnabled)
 
 bool Configuration::getAmplitudeEnabled(void)
 {
-    processTextAmplitude = settings.ui.amplitudeEnabled;
     return settings.ui.amplitudeEnabled;
 }
 
@@ -338,11 +333,6 @@ void Configuration::setGraphType(GraphType graphType)
 
 Configuration::GraphType Configuration::getGraphType(void)
 {
-    if (settings.ui.graphType == noGraph) {
-        processGraphAmplitude = false;
-    } else {
-        processGraphAmplitude = true;
-    }
     return settings.ui.graphType;
 }
 
@@ -395,13 +385,4 @@ void Configuration::setConfigurationDialogGeometry(QByteArray configurationDialo
 QByteArray Configuration::getConfigurationDialogGeometry(void)
 {
     return settings.windows.configurationDialogGeometry;
-}
-
-bool Configuration::getProcessAmplitude(void)
-{
-    if (processGraphAmplitude || processTextAmplitude) {
-        return true;
-    } else {
-        return false;
-    }
 }

--- a/Linux-Application/DomesdayDuplicator/configuration.cpp
+++ b/Linux-Application/DomesdayDuplicator/configuration.cpp
@@ -199,8 +199,6 @@ Configuration::CaptureFormat Configuration::convertIntToCaptureFormat(qint32 cap
     return CaptureFormat::tenBitPacked;
 }
 
-// Enum conversion from
-
 // Enum conversion from GraphType to int
 qint32 Configuration::convertGraphTypeToInt(GraphType graphType)
 {
@@ -402,7 +400,7 @@ QByteArray Configuration::getConfigurationDialogGeometry(void)
 bool Configuration::getProcessAmplitude(void)
 {
     if (processGraphAmplitude || processTextAmplitude) {
-    return true;
+        return true;
     } else {
         return false;
     }

--- a/Linux-Application/DomesdayDuplicator/configuration.h
+++ b/Linux-Application/DomesdayDuplicator/configuration.h
@@ -100,8 +100,6 @@ public:
     void setConfigurationDialogGeometry(QByteArray configurationDialogGeometry);
     QByteArray getConfigurationDialogGeometry(void);
 
-    static bool getProcessAmplitude(void);
-
 signals:
 
 public slots:

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -711,7 +711,6 @@ void MainWindow::on_capturePushButton_clicked()
 
         // Start graph processing
         amplitudeTimer->start(1000);
-
     } else {
         // Stop capture
         playerControl->stopAutomaticCapture(); // Stop auto-capture if in progress
@@ -845,38 +844,35 @@ void MainWindow::updatePlayerRemoteDialog(void)
     }
 }
 
-// Setup Main UI Graph Functions
-
+// Update amplitude graph
 void MainWindow::setupMainUIGraphs(void) {
-
-if (configuration->getGraphType() == Configuration::GraphType::QCPMean) {
-    ui->am->setVisible(true);
+    if (configuration->getGraphType() == Configuration::GraphType::QCPMean) {
+        ui->am->setVisible(true);
     } else {
-    ui->am->setVisible(false);
+        ui->am->setVisible(false);
     }
 }
 
 // Update amplitude label
-
 void MainWindow::updateAmplitude(void) {
     ui->meanAmplitudeLabel->setText(QString::number(AmplitudeMeasurement::getMeanAmplitude(), 'f', 3));
 }
 
 // Set up timers for amplitude processing
-
 void MainWindow::amplitudeSettings(void) {
-    // Set up a timer for amplitude processing
     amplitudeTimer = new QTimer(this);
-    if (configuration->getAmplitudeEnabled() == true) {
-    connect(amplitudeTimer, SIGNAL(timeout()), this, SLOT(updateAmplitude()));
-    ui->meanAmplitudeLabel->setText("0.000");
+
+    if (configuration->getAmplitudeEnabled()) {
+        connect(amplitudeTimer, SIGNAL(timeout()), this, SLOT(updateAmplitude()));
+        ui->meanAmplitudeLabel->setText("0.000");
     } else {
         disconnect(amplitudeTimer);
         ui->meanAmplitudeLabel->setText("N/A");
     }
+
     if (configuration->getGraphType() == Configuration::GraphType::QCPMean) {
-    connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(setBuffer()));
-    connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(plot()));
+        connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(setBuffer()));
+        connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(plot()));
     } else {
         disconnect(amplitudeTimer);
     }

--- a/Linux-Application/DomesdayDuplicator/mainwindow.h
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.h
@@ -56,7 +56,6 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    void setupMainUIGraphs(void);
 
 private slots:
     void deviceAttachedSignalHandler(void);
@@ -82,8 +81,7 @@ private slots:
     void transferFailedSignalHandler(void);
     void updateCaptureDuration(void);
     void updateStorageInformation(void);
-    void updateAmplitude(void);
-    void amplitudeSettings(void);
+    void updateAmplitudeLabel(void);
 
     void on_actionExit_triggered();
     void on_actionTest_mode_toggled(bool arg1);
@@ -131,6 +129,7 @@ private:
     void updateGuiForCaptureStop(void);
     void startPlayerControl(void);
     void updatePlayerRemoteDialog(void);
+    void updateAmplitudeUI(void);
 
 signals:
     void plotAmplitude(void);

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -777,7 +777,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
                 }
 
                 periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue),
-                                                 sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+                                                 TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
             }
 
             // Write the conversion buffer to disk
@@ -833,7 +833,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
                 }
 
                 periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue),
-                                                 sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+                                                 TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
             }
 
             // Write the conversion buffer to disk
@@ -854,7 +854,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
             conversionBuffer[pointer+1] = static_cast<unsigned char>((signedValue & 0xFF00) >> 8);
         }
 
-        periodicSignedValue = QByteArray(reinterpret_cast<char*>(conversionBuffer), sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+        periodicSignedValue = QByteArray(reinterpret_cast<char*>(conversionBuffer), TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
 
         // Write the conversion buffer to disk
         writeConversionBuffer(outputFile, TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
@@ -863,7 +863,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 
 void UsbCapture::writeConversionBuffer(QFile *outputFile, qint32 numBytes)
 {
-    qint64 bytesWritten = outputFile->write(reinterpret_cast<const char *>(conversionBuffer), sizeof(unsigned char) * numBytes);
+    qint64 bytesWritten = outputFile->write(reinterpret_cast<const char *>(conversionBuffer), numBytes);
     //qDebug() << "UsbCapture::writeBufferToDisk(): 10-bit - Written" << bytesWritten << "bytes to disk";
 
     // Check for a short write (which shouldn't happen, because outputFile is buffered) or a filesystem error

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -109,7 +109,7 @@ static QByteArray periodicSignedValue;
 
 // LibUSB transfer call-back handler (called when an in-flight transfer completes)
 static void LIBUSB_CALL bulkTransferCallback(struct libusb_transfer *transfer)
-{    
+{
     // Extract the user data
     transferUserDataStruct *transferUserData = static_cast<transferUserDataStruct *>(transfer->user_data);
 
@@ -318,7 +318,7 @@ void UsbCapture::run(void)
         freeDiskBuffers();
         return;
     }
-    
+
     // Save the current scheduling policy and parameters
 #ifdef _WIN32
     // TODO: Implement pthread-win32 for scheduling on Windows
@@ -761,8 +761,7 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
                 conversionBufferPointer += 5;
             }
 
-            if (Configuration::getProcessAmplitude() == true) {
-
+            if (Configuration::getProcessAmplitude()) {
                 // Translate the data in the disk buffer to scaled 16-bit signed data for amplitude processing
                 for (qint32 pointer = 0; pointer < (TRANSFERSIZE * TRANSFERSPERDISKBUFFER); pointer += 2) {
                     // Get the original 10-bit unsigned value from the disk data buffer
@@ -775,11 +774,10 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 
                     holdingSignedValue[pointer] = static_cast<unsigned char>(signedValue & 0x00FF);
                     holdingSignedValue[pointer+1] = static_cast<unsigned char>((signedValue & 0xFF00) >> 8);
+                }
 
-                    }
-
-            periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue), sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
-
+                periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue),
+                                                 sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
             }
 
             // Write the conversion buffer to disk
@@ -816,10 +814,9 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 
                 // Increment the conversion buffer pointer
                 conversionBufferPointer += 5;
-            }        
+            }
 
-            if (Configuration::getProcessAmplitude() == true) {
-
+            if (Configuration::getProcessAmplitude()) {
                 // Translate the data in the disk buffer to scaled 16-bit signed data for amplitude processing
                 for (qint32 pointer = 0; pointer < (TRANSFERSIZE * TRANSFERSPERDISKBUFFER); pointer += 2) {
                     // Get the original 10-bit unsigned value from the disk data buffer
@@ -833,10 +830,11 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
                     holdingSignedValue[pointer] = static_cast<unsigned char>(signedValue & 0x00FF);
                     holdingSignedValue[pointer+1] = static_cast<unsigned char>((signedValue & 0xFF00) >> 8);
 
-                    }
-
-                periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue), sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
                 }
+
+                periodicSignedValue = QByteArray(reinterpret_cast<char*>(holdingSignedValue),
+                                                 sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+            }
 
             // Write the conversion buffer to disk
             writeConversionBuffer(outputFile, conversionBufferPointer);
@@ -859,7 +857,6 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
         periodicSignedValue = QByteArray(reinterpret_cast<char*>(conversionBuffer), sizeof(unsigned char) * TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
 
         // Write the conversion buffer to disk
-
         writeConversionBuffer(outputFile, TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
     }
 }

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -53,7 +53,7 @@ public:
     qint32 getNumberOfDiskBuffersWritten(void);
     QString getLastError(void);
     static bool getOkToRename();
-    static QByteArray getBuffer();
+    static void getAmplitudeBuffer(const unsigned char **buffer, qint32 *numBytes);
 
 signals:
     void transferFailed(void);


### PR DESCRIPTION
Various work on @TokugawaHeavyIndustries's new amplitude display code - mostly to improve the performance, both by moving work out of the realtime capture thread and by simplifying the stats calculations. See the individual commits for more details.

This removes the code that was using QtMultimedia, so it works on Qt 5 again. Note that the first stanza in the CI config also tests the oldest version of Ubuntu we support - if we do remove Qt 5 support in the future (which we shouldn't do for a while - Qt 6 is still pretty new), this should be kept but switched to Qt 6.

There are still some oddities in the GUI that need addressing - the default window size is wrong, and the configuration window could do with being a proper layout rather than using absolute positioning.

Given what the FM signals DDD works with look like, it might be worth capping the number of samples the amplitude code looks at - it doesn't really need to analyse a full disk buffer's worth each time to get a good idea of the amplitude.

This also includes the CMake fixes that were in #131.