### PR TITLE
Rebuild the main and preferences windows using layouts

### DIFF
--- a/Linux-Application/DomesdayDuplicator/aboutdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/aboutdialog.ui
@@ -57,7 +57,7 @@
     <attribute name="title">
      <string>About DdD</string>
     </attribute>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="logoLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -76,7 +76,7 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-    <widget class="QTextBrowser" name="textBrowser_3">
+    <widget class="QTextBrowser" name="aboutTextBrowser">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -106,7 +106,7 @@ p, li { white-space: pre-wrap; }
     <attribute name="title">
      <string>Licensing</string>
     </attribute>
-    <widget class="QTextBrowser" name="textBrowser">
+    <widget class="QTextBrowser" name="licenseTextBrowser">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -276,7 +276,7 @@ p, li { white-space: pre-wrap; }
     <attribute name="title">
      <string>Credits</string>
     </attribute>
-    <widget class="QTextBrowser" name="textBrowser_2">
+    <widget class="QTextBrowser" name="creditsTextBrowser">
      <property name="geometry">
       <rect>
        <x>10</x>

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Advanced capture naming</string>
   </property>
-  <widget class="QGroupBox" name="groupBox_2">
+  <widget class="QGroupBox" name="advancedNamingGroupBox">
    <property name="geometry">
     <rect>
      <x>10</x>
@@ -339,8 +339,8 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="audioButtonGroup"/>
   <buttongroup name="formatButtonGroup"/>
   <buttongroup name="discTypeButtonGroup"/>
+  <buttongroup name="audioButtonGroup"/>
  </buttongroups>
 </ui>

--- a/Linux-Application/DomesdayDuplicator/automaticcapturedialog.ui
+++ b/Linux-Application/DomesdayDuplicator/automaticcapturedialog.ui
@@ -67,7 +67,7 @@
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QLabel" name="label_5">
+     <widget class="QLabel" name="captureStatusPreLabel">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -100,7 +100,7 @@
      <property name="title">
       <string>CAV capture:</string>
      </property>
-     <widget class="QLabel" name="label">
+     <widget class="QLabel" name="startFrameLabel">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -116,7 +116,7 @@
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
-     <widget class="QLabel" name="label_2">
+     <widget class="QLabel" name="endFrameLabel">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -181,7 +181,7 @@
      <property name="title">
       <string>CLV capture:</string>
      </property>
-     <widget class="QLabel" name="label_3">
+     <widget class="QLabel" name="endTimeLabel">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -197,7 +197,7 @@
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
      </widget>
-     <widget class="QLabel" name="label_4">
+     <widget class="QLabel" name="startTimeLabel">
       <property name="geometry">
        <rect>
         <x>10</x>

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -6,386 +6,435 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>420</width>
-    <height>240</height>
+    <width>450</width>
+    <height>290</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>420</width>
-    <height>240</height>
+    <width>450</width>
+    <height>290</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
-  <widget class="QDialogButtonBox" name="buttonBox">
-   <property name="geometry">
-    <rect>
-     <x>30</x>
-     <y>200</y>
-     <width>341</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-   <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
-   </property>
-  </widget>
-  <widget class="QTabWidget" name="tabWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>400</width>
-     <height>180</height>
-    </rect>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>400</width>
-     <height>180</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>360</width>
-     <height>180</height>
-    </size>
-   </property>
-   <property name="currentIndex">
-    <number>3</number>
-   </property>
-   <widget class="QWidget" name="capture">
-    <attribute name="title">
-     <string>Capture</string>
-    </attribute>
-    <widget class="QLabel" name="captureDirectoryLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>11</y>
-       <width>111</width>
-       <height>20</height>
-      </rect>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="minimumSize">
+      <size>
+       <width>400</width>
+       <height>180</height>
+      </size>
      </property>
-     <property name="text">
-      <string>Capture directory:</string>
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     <widget class="QWidget" name="capture">
+      <attribute name="title">
+       <string>Capture</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="captureDirectoryHorizontalLayout">
+         <item>
+          <widget class="QLabel" name="captureDirectoryLabel">
+           <property name="text">
+            <string>Capture directory:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="captureDirectoryLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="captureDirectoryPushButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Minimum</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>12</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="saveAsTenBitRadioButton">
+         <property name="text">
+          <string>Save captures as 10-bit packed unsigned data</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="saveAsSixteenBitRadioButton">
+         <property name="text">
+          <string>Save captures as 16-bit signed scaled data</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="saveAs10BitCdRadioButton">
+         <property name="text">
+          <string>Save captures as 10-bit packed (4:1 decimation for CD)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="usb">
+      <attribute name="title">
+       <string>USB</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QGridLayout" name="usbDeviceGridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="vendorIdLabel">
+           <property name="text">
+            <string>Vendor ID:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="vendorIdLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="productIdLabel">
+           <property name="text">
+            <string>Product ID:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="productIdLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="defaultIdsLabel">
+         <property name="text">
+          <string>Default is: 7504/24635</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="playerControl">
+      <attribute name="title">
+       <string>Player Control</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QGridLayout" name="serialDeviceGridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="serialDeviceLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Serial device:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="serialDeviceComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="serialSpeedLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Serial speed:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="serialSpeedComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>12</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keyLockCheckBox">
+         <property name="text">
+          <string>Engage key-lock</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="userInterface">
+      <attribute name="title">
+       <string>User Interface</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="amplitudeLabel">
+         <property name="text">
+          <string>RF Signal Amplitude Processing:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>12</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="textLabelOptionsLabel">
+         <property name="text">
+          <string>Text Label Options (Low CPU usage):</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="amplitudeProcessingCheckBox">
+         <property name="text">
+          <string>RMS (Average)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>12</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="graphingOptionsLabel">
+         <property name="text">
+          <string>Graphing Options (Higher CPU usage):</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="amplitudeGraphRadioButton">
+         <property name="text">
+          <string>Mean Amplitude (QCP)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="noGraphButton">
+         <property name="text">
+          <string>None</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
      </property>
     </widget>
-    <widget class="QLineEdit" name="captureDirectoryLineEdit">
-     <property name="geometry">
-      <rect>
-       <x>132</x>
-       <y>10</y>
-       <width>251</width>
-       <height>21</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="captureDirectoryPushButton">
-     <property name="geometry">
-      <rect>
-       <x>300</x>
-       <y>40</y>
-       <width>81</width>
-       <height>24</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="saveAsSixteenBitRadioButton">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>100</y>
-       <width>361</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Save captures as 16-bit signed scaled data</string>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="saveAsTenBitRadioButton">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>80</y>
-       <width>361</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Save captures as 10-bit packed unsigned data</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="saveAs10BitCdRadioButton">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>120</y>
-       <width>361</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Save captures as 10-bit packed (4:1 decimation for CD)</string>
-     </property>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="usb">
-    <attribute name="title">
-     <string>USB</string>
-    </attribute>
-    <widget class="QLabel" name="vendorIdLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>111</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Vendor ID:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="productIdLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>40</y>
-       <width>111</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Product ID:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="vendorIdLineEdit">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>10</y>
-       <width>151</width>
-       <height>20</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="productIdLineEdit">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>40</y>
-       <width>151</width>
-       <height>20</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QLabel" name="defaultIdsLabel">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>70</y>
-       <width>251</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Default is: 7504/24635</string>
-     </property>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="playerControl">
-    <attribute name="title">
-     <string>Player Control</string>
-    </attribute>
-    <widget class="QLabel" name="serialDeviceLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>111</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Serial device:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="serialSpeedLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>40</y>
-       <width>111</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Serial speed:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QComboBox" name="serialDeviceComboBox">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>10</y>
-       <width>181</width>
-       <height>24</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QComboBox" name="serialSpeedComboBox">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>40</y>
-       <width>181</width>
-       <height>24</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QCheckBox" name="keyLockCheckBox">
-     <property name="geometry">
-      <rect>
-       <x>130</x>
-       <y>70</y>
-       <width>251</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Engage key-lock</string>
-     </property>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="userInterface">
-    <attribute name="title">
-     <string>User Interface</string>
-    </attribute>
-    <widget class="QRadioButton" name="amplitudeGraphRadioButton">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>110</y>
-       <width>151</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Mean Amplitude (QCP)</string>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="noGraphButton">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>90</y>
-       <width>89</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>None</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QLabel" name="graphingOptionsLabel">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>70</y>
-       <width>211</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Graphing Options (Higher CPU usage):</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="amplitudeLabel">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>0</y>
-       <width>171</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>RF Signal Amplitude Processing:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QCheckBox" name="amplitudeProcessingCheckBox">
-     <property name="geometry">
-      <rect>
-       <x>20</x>
-       <y>50</y>
-       <width>101</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>RMS (Average)</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="textLabelOptionsLabel">
-     <property name="geometry">
-      <rect>
-       <x>0</x>
-       <y>30</y>
-       <width>211</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Text Label Options (Low CPU usage):</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </widget>
-  </widget>
+   </item>
+  </layout>
  </widget>
  <tabstops>
-  <tabstop>tabWidget</tabstop>
   <tabstop>captureDirectoryLineEdit</tabstop>
-  <tabstop>captureDirectoryPushButton</tabstop>
   <tabstop>saveAsTenBitRadioButton</tabstop>
   <tabstop>saveAsSixteenBitRadioButton</tabstop>
   <tabstop>vendorIdLineEdit</tabstop>

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -63,7 +63,7 @@
     <attribute name="title">
      <string>Capture</string>
     </attribute>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="captureDirectoryLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -149,7 +149,7 @@
     <attribute name="title">
      <string>USB</string>
     </attribute>
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="vendorIdLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -165,7 +165,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="productIdLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -201,7 +201,7 @@
       </rect>
      </property>
     </widget>
-    <widget class="QLabel" name="label_7">
+    <widget class="QLabel" name="defaultIdsLabel">
      <property name="geometry">
       <rect>
        <x>130</x>
@@ -219,7 +219,7 @@
     <attribute name="title">
      <string>Player Control</string>
     </attribute>
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="serialDeviceLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -235,7 +235,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_5">
+    <widget class="QLabel" name="serialSpeedLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -318,7 +318,7 @@
       <bool>true</bool>
      </property>
     </widget>
-    <widget class="QLabel" name="label_6">
+    <widget class="QLabel" name="graphingOptionsLabel">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -334,7 +334,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLabel" name="label_8">
+    <widget class="QLabel" name="amplitudeLabel">
      <property name="geometry">
       <rect>
        <x>0</x>
@@ -363,7 +363,7 @@
       <string>RMS (Average)</string>
      </property>
     </widget>
-    <widget class="QLabel" name="label_9">
+    <widget class="QLabel" name="textLabelOptionsLabel">
      <property name="geometry">
       <rect>
        <x>0</x>

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -510,7 +510,7 @@ void MainWindow::updateCaptureStatistics(void)
         mbWritten = usbDevice->getNumberOfDiskBuffersWritten() * 40; // 10-bit is 40MiB per buffer
     else mbWritten = usbDevice->getNumberOfDiskBuffersWritten() * 10; // 10-bit 4:1 is 8MiB per buffer
 
-    ui->numberOfDiskBuffersWrittenLabel->setText(QString::number(mbWritten) + (tr(" MiB")));
+    ui->dataCapturedLabel->setText(QString::number(mbWritten) + (tr(" MiB")));
 }
 
 // Update the player control labels

--- a/Linux-Application/DomesdayDuplicator/mainwindow.ui
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>470</height>
+    <height>520</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>480</width>
-    <height>470</height>
+    <height>520</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -27,119 +27,135 @@
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
      <widget class="QGroupBox" name="captureControlGroupBox">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>60</verstretch>
+       </sizepolicy>
+      </property>
       <property name="minimumSize">
        <size>
         <width>0</width>
-        <height>145</height>
+        <height>0</height>
        </size>
       </property>
       <property name="title">
        <string>Capture control:</string>
       </property>
-      <widget class="QCheckBox" name="limitDurationCheckBox">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>80</y>
-         <width>141</width>
-         <height>21</height>
-        </rect>
+      <layout class="QHBoxLayout" name="captureControlHorizontalLayout">
+       <property name="spacing">
+        <number>20</number>
        </property>
-       <property name="text">
-        <string>Limit duration</string>
-       </property>
-      </widget>
-      <widget class="QTimeEdit" name="durationLimitTimeEdit">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="geometry">
-        <rect>
-         <x>160</x>
-         <y>80</y>
-         <width>118</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="displayFormat">
-        <string>HH:mm:ss</string>
-       </property>
-      </widget>
-      <widget class="QPushButton" name="capturePushButton">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>30</y>
-         <width>270</width>
-         <height>40</height>
-        </rect>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>270</width>
-         <height>40</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>240</width>
-         <height>40</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Capture</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="dddLogoLabel">
-       <property name="geometry">
-        <rect>
-         <x>300</x>
-         <y>20</y>
-         <width>171</width>
-         <height>101</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="resources.qrc">:/graphics/logo/Graphics/Domesday Duplicator logo colour 150px.png</pixmap>
-       </property>
-      </widget>
-      <widget class="QLabel" name="spaceAvailablePreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>110</y>
-         <width>121</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Space available:</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="spaceAvailableLabel">
-       <property name="geometry">
-        <rect>
-         <x>160</x>
-         <y>110</y>
-         <width>121</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>00:00:00</string>
-       </property>
-      </widget>
+       <item>
+        <layout class="QVBoxLayout" name="captureControlVerticalLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="capturePushButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Capture</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="captureControlGridLayout">
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="limitDurationCheckBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Limit duration</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QTimeEdit" name="durationLimitTimeEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="displayFormat">
+              <string>HH:mm:ss</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="spaceAvailablePreLabel">
+             <property name="text">
+              <string>Space available:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="spaceAvailableLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>00:00:00</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="dddLogoLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="resources.qrc">:/graphics/logo/Graphics/Domesday Duplicator logo colour 150px.png</pixmap>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>
      <widget class="QGroupBox" name="captureStatsGroupBox">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>40</verstretch>
+       </sizepolicy>
+      </property>
       <property name="minimumSize">
        <size>
         <width>0</width>
-        <height>105</height>
+        <height>0</height>
        </size>
       </property>
       <property name="maximumSize">
@@ -151,132 +167,138 @@
       <property name="title">
        <string>Capture statistics:</string>
       </property>
-      <widget class="QLabel" name="numberOfTransfersPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>40</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Transfers:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="numberOfTransfersLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>40</y>
-         <width>231</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>0</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="dataCapturedPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>60</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Captured:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="dataCapturedLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>60</y>
-         <width>231</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>0 MiB</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="durationPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>20</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Duration:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="durationLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>20</y>
-         <width>231</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>00:00:00</string>
-       </property>
-      </widget>
-      <widget class="AmplitudeMeasurement" name="am" native="true">
-       <property name="geometry">
-        <rect>
-         <x>180</x>
-         <y>20</y>
-         <width>271</width>
-         <height>81</height>
-        </rect>
-       </property>
-      </widget>
-      <widget class="QLabel" name="meanAmplitudePreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>80</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Amplitude:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="meanAmplitudeLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>80</y>
-         <width>41</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>0</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="captureStatsHorizontalLayout">
+       <item>
+        <layout class="QGridLayout" name="captureStatsGridLayout" columnminimumwidth="80,0">
+         <item row="0" column="0">
+          <widget class="QLabel" name="durationPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Duration:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="durationLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>00:00:00</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="numberOfTransfersPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Transfers:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="numberOfTransfersLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="dataCapturedPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Captured:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="dataCapturedLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0 MiB</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="meanAmplitudePreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Amplitude:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="meanAmplitudeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="AmplitudeMeasurement" name="am" native="true">
+         <property name="minimumSize">
+          <size>
+           <width>180</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>
@@ -285,15 +307,15 @@
        <bool>true</bool>
       </property>
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
+        <verstretch>40</verstretch>
        </sizepolicy>
       </property>
       <property name="minimumSize">
        <size>
         <width>0</width>
-        <height>140</height>
+        <height>0</height>
        </size>
       </property>
       <property name="maximumSize">
@@ -305,122 +327,128 @@
       <property name="title">
        <string>Player information:</string>
       </property>
-      <widget class="QLabel" name="playerStatusPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>70</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Status:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerPositionPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>90</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Position:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerStatusLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>70</y>
-         <width>171</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Unknown</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerPositionLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>90</y>
-         <width>171</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Unknown</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerModelPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>50</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Model:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerModelLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>50</y>
-         <width>171</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Unknown</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerPortLabel">
-       <property name="geometry">
-        <rect>
-         <x>100</x>
-         <y>30</y>
-         <width>171</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Unknown</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="playerPortPreLabel">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>30</y>
-         <width>81</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Port:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="playerInfoHorizontalLayout">
+       <item>
+        <layout class="QGridLayout" name="playerInfoGridLayout" columnminimumwidth="80,0">
+         <item row="0" column="0">
+          <widget class="QLabel" name="playerPortPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Port:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="playerPortLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Unknown</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="playerModelPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Model:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="playerModelLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Unknown</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="playerStatusPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Status:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="playerStatusLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Unknown</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="playerPositionPreLabel">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Position:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="playerPositionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Unknown</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>
@@ -431,7 +459,7 @@
      <x>0</x>
      <y>0</y>
      <width>480</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/Linux-Application/DomesdayDuplicator/mainwindow.ui
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.ui
@@ -26,7 +26,7 @@
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QGroupBox" name="groupBox_3">
+     <widget class="QGroupBox" name="captureControlGroupBox">
       <property name="minimumSize">
        <size>
         <width>0</width>
@@ -90,7 +90,7 @@
         <string>Capture</string>
        </property>
       </widget>
-      <widget class="QLabel" name="label_6">
+      <widget class="QLabel" name="dddLogoLabel">
        <property name="geometry">
         <rect>
          <x>300</x>
@@ -106,7 +106,7 @@
         <pixmap resource="resources.qrc">:/graphics/logo/Graphics/Domesday Duplicator logo colour 150px.png</pixmap>
        </property>
       </widget>
-      <widget class="QLabel" name="label_7">
+      <widget class="QLabel" name="spaceAvailablePreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -135,7 +135,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="groupBox">
+     <widget class="QGroupBox" name="captureStatsGroupBox">
       <property name="minimumSize">
        <size>
         <width>0</width>
@@ -151,7 +151,7 @@
       <property name="title">
        <string>Capture statistics:</string>
       </property>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="numberOfTransfersPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -180,7 +180,7 @@
         <string>0</string>
        </property>
       </widget>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="dataCapturedPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -196,7 +196,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="QLabel" name="numberOfDiskBuffersWrittenLabel">
+      <widget class="QLabel" name="dataCapturedLabel">
        <property name="geometry">
         <rect>
          <x>100</x>
@@ -209,7 +209,7 @@
         <string>0 MiB</string>
        </property>
       </widget>
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="durationPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -248,7 +248,7 @@
         </rect>
        </property>
       </widget>
-      <widget class="QLabel" name="label_10">
+      <widget class="QLabel" name="meanAmplitudePreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -280,7 +280,7 @@
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="groupBox_2">
+     <widget class="QGroupBox" name="playerInfoGroupBox">
       <property name="enabled">
        <bool>true</bool>
       </property>
@@ -305,7 +305,7 @@
       <property name="title">
        <string>Player information:</string>
       </property>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="playerStatusPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -321,7 +321,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="playerPositionPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -363,7 +363,7 @@
         <string>Unknown</string>
        </property>
       </widget>
-      <widget class="QLabel" name="label_8">
+      <widget class="QLabel" name="playerModelPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -405,7 +405,7 @@
         <string>Unknown</string>
        </property>
       </widget>
-      <widget class="QLabel" name="label_9">
+      <widget class="QLabel" name="playerPortPreLabel">
        <property name="geometry">
         <rect>
          <x>10</x>


### PR DESCRIPTION
These windows used absolute positioning, so they were a bit dodgy with large font sizes anyway, and the new widgets for the amplitude display made them very cramped. Rebuild them with layouts so they can adapt to the window size automatically. I haven't changed any of the wording, so this shouldn't need any documentation changes.

The one thing that's still a fixed size is the window itself - does anyone know how to make Qt best-fit the window size?

Before:

![beforemain](https://user-images.githubusercontent.com/436317/211440874-1ec9e07d-678a-47f0-a125-db7ca9c2f4ef.png)
![beforeprefs](https://user-images.githubusercontent.com/436317/211440884-0668be94-fd54-483e-9e90-f3caa7f7c1b1.png)

After:

![aftermain](https://user-images.githubusercontent.com/436317/211440899-2a82ff12-226c-4648-9abf-6ee95b565bb1.png)
![afterprefs](https://user-images.githubusercontent.com/436317/211440908-ac9df0d5-4f8f-4f82-8cca-36c7b20f5739.png)