### PR TITLE
Only capture 1024 samples when measuring amplitude

### DIFF
--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -106,7 +106,8 @@ double AmplitudeMeasurement::getMeanAmplitude()
     }
 
     std::copy(rollingAmp.begin() + 1, rollingAmp.end(), rollingAmp.begin());
-    rollingAmp.back() = sqrt(posSum / (MAX_SAMPLE * MAX_SAMPLE * (numSamples / 2)));
+    // Divide by 2 here for a crest factor of sqrt(2) (i.e. assume a sin-ish signal)
+    rollingAmp.back() = sqrt(posSum / (MAX_SAMPLE * MAX_SAMPLE * numSamples / 2.0));
 
     if (std::find(rollingAmp.begin(), rollingAmp.end(), 0.0) != rollingAmp.end()) {
         // rollingAmp (probably) isn't full yet -- return the latest value

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -79,9 +79,9 @@ void AmplitudeMeasurement::updateBuffer()
 // Draw the graph
 void AmplitudeMeasurement::plotGraph()
 {
-    // Add every millionth point to graphYValues and shift along
+    // Add every 100th point to graphYValues and shift along
     qint32 numSamples = inputSamples.size();
-    for (int i = 0; i < numSamples; i += 1000000) {
+    for (int i = 0; i < numSamples; i += 100) {
         graphYValues.append(inputSamples[i] / MAX_SAMPLE);
     }
     if (graphYValues.size() > GRAPH_POINTS) {

--- a/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
+++ b/Linux-Application/DomesdayDuplicator/amplitudemeasurement.cpp
@@ -101,8 +101,8 @@ double AmplitudeMeasurement::getMeanAmplitude()
 {
     qint32 numSamples = inputSamples.size();
     double posSum = 0.0;
-    for (int i = 0; i < numSamples; i++){
-        posSum += inputSamples[i] * inputSamples[i];
+    for (qint16 sample: inputSamples) {
+        posSum += static_cast<double>(sample) * static_cast<double>(sample);
     }
 
     std::copy(rollingAmp.begin() + 1, rollingAmp.end(), rollingAmp.begin());

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -48,6 +48,9 @@
 #define TRANSFERSPERDISKBUFFER 256
 #define NUMBEROFDISKBUFFERS 4
 
+// The number of bytes to capture for amplitude metering.
+#define AMPLITUDESIZE (1024 * 2)
+
 // Note:
 //
 // When saving in 16-bit format, each disk buffer represents 64 Mbytes of data
@@ -818,9 +821,9 @@ void UsbCapture::writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber)
 
     // Has getAmplitudeBuffer requested a new buffer?
     if (needAmplitudeUpdate) {
-        // Copy this disk buffer into the amplitude buffer that's not currently being read
+        // Copy the start of this disk buffer into the amplitude buffer that's not currently being read
         qint32 num = 1 - currentAmplitudeBuffer;
-        memcpy(amplitudeBuffers[num], diskBuffers[diskBufferNumber], TRANSFERSIZE * TRANSFERSPERDISKBUFFER);
+        memcpy(amplitudeBuffers[num], diskBuffers[diskBufferNumber], AMPLITUDESIZE);
 
         // Flip the buffers
         currentAmplitudeBuffer = num;
@@ -887,7 +890,7 @@ void UsbCapture::getAmplitudeBuffer(const unsigned char **buffer, qint32 *numByt
 {
     // Get the most-recently-updated buffer (reading the atomic, to ensure this thread has seen the writes to it)
     *buffer = amplitudeBuffers[currentAmplitudeBuffer];
-    *numBytes = TRANSFERSIZE * TRANSFERSPERDISKBUFFER;
+    *numBytes = AMPLITUDESIZE;
 
     // Tell the capture thread to grab a new buffer
     needAmplitudeUpdate = true;


### PR DESCRIPTION
CC @TokugawaHeavyIndustries.

For the FM signals found on LaserDisc and videotape, this is plenty to get a reasonable idea of the signal amplitude, and it makes the cost of having the text amplitude display turned on insignificant.