### PR TITLE
Update tab order in DomesdayDuplicator's dialogs

### DIFF
--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.ui
@@ -332,15 +332,24 @@
   <tabstop>formatCheckBox</tabstop>
   <tabstop>formatNtscRadioButton</tabstop>
   <tabstop>formatPalRadioButton</tabstop>
+  <tabstop>audioCheckBox</tabstop>
+  <tabstop>audioDefaultRadioButton</tabstop>
+  <tabstop>audioAnalogueRadioButton</tabstop>
+  <tabstop>audioAc3RadioButton</tabstop>
+  <tabstop>audioDtsRadioButton</tabstop>
   <tabstop>discSideCheckBox</tabstop>
+  <tabstop>discSideSpinBox</tabstop>
   <tabstop>notesCheckBox</tabstop>
   <tabstop>notesLineEdit</tabstop>
+  <tabstop>mintCheckBox</tabstop>
+  <tabstop>mintLineEdit</tabstop>
+  <tabstop>durationCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>
  <buttongroups>
+  <buttongroup name="audioButtonGroup"/>
   <buttongroup name="formatButtonGroup"/>
   <buttongroup name="discTypeButtonGroup"/>
-  <buttongroup name="audioButtonGroup"/>
  </buttongroups>
 </ui>

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -434,13 +434,20 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>tabWidget</tabstop>
   <tabstop>captureDirectoryLineEdit</tabstop>
+  <tabstop>captureDirectoryPushButton</tabstop>
   <tabstop>saveAsTenBitRadioButton</tabstop>
   <tabstop>saveAsSixteenBitRadioButton</tabstop>
+  <tabstop>saveAs10BitCdRadioButton</tabstop>
   <tabstop>vendorIdLineEdit</tabstop>
   <tabstop>productIdLineEdit</tabstop>
   <tabstop>serialDeviceComboBox</tabstop>
   <tabstop>serialSpeedComboBox</tabstop>
+  <tabstop>keyLockCheckBox</tabstop>
+  <tabstop>amplitudeProcessingCheckBox</tabstop>
+  <tabstop>amplitudeGraphRadioButton</tabstop>
+  <tabstop>noGraphButton</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This makes keyboard navigation step through widgets in a more sensible order, especially in the advanced naming dialog.