### PR TITLE
Improvements to per-side notes and mint marks

### DIFF
--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -123,7 +123,7 @@ bool AdvancedNamingDialog::getDurationChecked()
 }
 
 // Update the GUI based on the state of the check boxes
-void AdvancedNamingDialog::updateGui(void)
+void AdvancedNamingDialog::updateGui()
 {
     if (ui->discTitleCheckBox->isChecked()) {
         ui->discTitleLineEdit->setEnabled(true);
@@ -180,7 +180,7 @@ void AdvancedNamingDialog::updateGui(void)
 }
 
 // Update the GUI and hold values from previous side input
-void AdvancedNamingDialog::updateSideHoldings(void)
+void AdvancedNamingDialog::updateSideHoldings()
 {
     if (ui->mintCheckBox->isChecked()) {
         mintHolding[discSideSpinBoxPrevVal] = ui->mintLineEdit->text();

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -122,6 +122,18 @@ bool AdvancedNamingDialog::getDurationChecked()
     return fileDurationBox;
 }
 
+// Enable or disable per-side notes
+void AdvancedNamingDialog::setPerSideNotesEnabled(bool enabled)
+{
+    perSideNotesEnabled = enabled;
+}
+
+// Enable or disable per-side mint marks
+void AdvancedNamingDialog::setPerSideMintEnabled(bool enabled)
+{
+    perSideMintEnabled = enabled;
+}
+
 // Update the GUI based on the state of the check boxes
 void AdvancedNamingDialog::updateGui()
 {
@@ -182,14 +194,14 @@ void AdvancedNamingDialog::updateGui()
 // Update the GUI and hold values from previous side input
 void AdvancedNamingDialog::updateSideHoldings()
 {
-    if (ui->mintCheckBox->isChecked()) {
-        mintHolding[discSideSpinBoxPrevVal] = ui->mintLineEdit->text();
-        ui->mintLineEdit->setText(mintHolding[ui->discSideSpinBox->value()]);
-    }
-
-    if (ui->notesCheckBox->isChecked()) {
+    if (perSideNotesEnabled && ui->notesCheckBox->isChecked()) {
         notesHolding[discSideSpinBoxPrevVal] = ui->notesLineEdit->text();
         ui->notesLineEdit->setText(notesHolding[ui->discSideSpinBox->value()]);
+    }
+
+    if (perSideMintEnabled && ui->mintCheckBox->isChecked()) {
+        mintHolding[discSideSpinBoxPrevVal] = ui->mintLineEdit->text();
+        ui->mintLineEdit->setText(mintHolding[ui->discSideSpinBox->value()]);
     }
 
     discSideSpinBoxPrevVal = ui->discSideSpinBox->value();

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.cpp
@@ -95,18 +95,12 @@ QString AdvancedNamingDialog::getFileName(bool isTestData)
             fileName += QString("_side%1").arg(ui->discSideSpinBox->value());
         }
 
-        // Require additional conditions to account for side 1 notes/mint without changing spinbox value
-        if (ui->notesCheckBox->isChecked() and notesHolding[ui->discSideSpinBox->value()].isNull()) {
+        if (ui->notesCheckBox->isChecked()) {
             fileName += "_" + ui->notesLineEdit->text();
-        } else {
-            fileName += "_" + notesHolding[ui->discSideSpinBox->value()];
         }
 
-        // Require additional conditions to account for side 1 notes/mint without changing spinbox value
-        if (ui->mintCheckBox->isChecked() and mintHolding[ui->discSideSpinBox->value()].isNull()) {
+        if (ui->mintCheckBox->isChecked()) {
             fileName += "_" + ui->mintLineEdit->text();
-        } else {
-            fileName += "_" + mintHolding[ui->discSideSpinBox->value()];
         }
 
         // Add the date/time stamp
@@ -190,22 +184,12 @@ void AdvancedNamingDialog::updateSideHoldings(void)
 {
     if (ui->mintCheckBox->isChecked()) {
         mintHolding[discSideSpinBoxPrevVal] = ui->mintLineEdit->text();
-
-        if (mintHolding[ui->discSideSpinBox->value()].isNull()) {
-            ui->mintLineEdit->setText("");
-        } else {
-            ui->mintLineEdit->setText(mintHolding[ui->discSideSpinBox->value()]);
-        }
+        ui->mintLineEdit->setText(mintHolding[ui->discSideSpinBox->value()]);
     }
 
     if (ui->notesCheckBox->isChecked()) {
         notesHolding[discSideSpinBoxPrevVal] = ui->notesLineEdit->text();
-
-        if (notesHolding[ui->discSideSpinBox->value()].isNull()) {
-            ui->notesLineEdit->setText("");
-        } else {
-            ui->notesLineEdit->setText(notesHolding[ui->discSideSpinBox->value()]);
-        }
+        ui->notesLineEdit->setText(notesHolding[ui->discSideSpinBox->value()]);
     }
 
     discSideSpinBoxPrevVal = ui->discSideSpinBox->value();
@@ -249,11 +233,9 @@ void AdvancedNamingDialog::on_mintCheckBox_clicked()
 void AdvancedNamingDialog::on_durationCheckBox_clicked()
 {
     updateGui();
-
 }
 
 void AdvancedNamingDialog::on_discSideSpinBox_valueChanged()
 {
     updateSideHoldings();
-
 }

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
@@ -47,6 +47,9 @@ public:
     QString getFileName(bool isTestData);
     bool getDurationChecked();
 
+    void setPerSideNotesEnabled(bool enabled);
+    void setPerSideMintEnabled(bool enabled);
+
 private slots:
     void on_discTitleCheckBox_clicked();
     void on_discTypeCheckBox_clicked();
@@ -63,8 +66,11 @@ private:
 
     void updateGui();
     void updateSideHoldings();
+
     int discSideSpinBoxPrevVal = 1;
+    bool perSideNotesEnabled = false;
     QString notesHolding[100];
+    bool perSideMintEnabled = false;
     QString mintHolding[100];
 };
 

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
@@ -61,8 +61,8 @@ private slots:
 private:
     Ui::AdvancedNamingDialog *ui;
 
-    void updateGui(void);
-    void updateSideHoldings(void);
+    void updateGui();
+    void updateSideHoldings();
     int discSideSpinBoxPrevVal = 1;
     QString notesHolding[100];
     QString mintHolding[100];

--- a/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
+++ b/Linux-Application/DomesdayDuplicator/advancednamingdialog.h
@@ -64,8 +64,8 @@ private:
     void updateGui(void);
     void updateSideHoldings(void);
     int discSideSpinBoxPrevVal = 1;
-    QString notesHolding[99];
-    QString mintHolding[99];
+    QString notesHolding[100];
+    QString mintHolding[100];
 };
 
 #endif // ADVANCEDNAMINGDIALOG_H

--- a/Linux-Application/DomesdayDuplicator/automaticcapturedialog.h
+++ b/Linux-Application/DomesdayDuplicator/automaticcapturedialog.h
@@ -62,7 +62,7 @@ public:
 
 signals:
     void startAutomaticCapture(CaptureType captureType, qint32 startAddress, qint32 endAddress, DiscType discType);
-    void stopAutomaticCapture(void);
+    void stopAutomaticCapture();
 
 private slots:
     void on_wholeDiscRadioButton_clicked();

--- a/Linux-Application/DomesdayDuplicator/configuration.cpp
+++ b/Linux-Application/DomesdayDuplicator/configuration.cpp
@@ -66,6 +66,8 @@ void Configuration::writeConfiguration()
 
     // UI
     configuration->beginGroup("ui");
+    configuration->setValue("perSideNotesEnabled", settings.ui.perSideNotesEnabled);
+    configuration->setValue("perSideMintEnabled", settings.ui.perSideMintEnabled);
     configuration->setValue("amplitudeEnabled", settings.ui.amplitudeLabelEnabled);
     configuration->setValue("graphType", settings.ui.amplitudeChartEnabled ? 1 : 0);
     configuration->endGroup();
@@ -111,6 +113,8 @@ void Configuration::readConfiguration()
 
     // UI
     configuration->beginGroup("ui");
+    settings.ui.perSideNotesEnabled = configuration->value("perSideNotesEnabled").toBool();
+    settings.ui.perSideMintEnabled = configuration->value("perSideMintEnabled").toBool();
     settings.ui.amplitudeLabelEnabled = configuration->value("amplitudeEnabled").toBool();
     settings.ui.amplitudeChartEnabled = configuration->value("graphType").toInt() > 0;
     configuration->endGroup();
@@ -148,6 +152,8 @@ void Configuration::setDefault()
     settings.capture.captureFormat = CaptureFormat::tenBitPacked;
 
     // UI
+    settings.ui.perSideNotesEnabled = false;
+    settings.ui.perSideMintEnabled = false;
     settings.ui.amplitudeLabelEnabled = false;
     settings.ui.amplitudeChartEnabled = false;
 
@@ -296,6 +302,26 @@ bool Configuration::getKeyLock()
 }
 
 // UI settings
+void Configuration::setPerSideNotesEnabled(bool enabled)
+{
+    settings.ui.perSideNotesEnabled = enabled;
+}
+
+bool Configuration::getPerSideNotesEnabled()
+{
+    return settings.ui.perSideNotesEnabled;
+}
+
+void Configuration::setPerSideMintEnabled(bool enabled)
+{
+    settings.ui.perSideMintEnabled = enabled;
+}
+
+bool Configuration::getPerSideMintEnabled()
+{
+    return settings.ui.perSideMintEnabled;
+}
+
 void Configuration::setAmplitudeLabelEnabled(bool enabled)
 {
     settings.ui.amplitudeLabelEnabled = enabled;

--- a/Linux-Application/DomesdayDuplicator/configuration.cpp
+++ b/Linux-Application/DomesdayDuplicator/configuration.cpp
@@ -53,7 +53,7 @@ Configuration::Configuration(QObject *parent) : QObject(parent)
     }
 }
 
-void Configuration::writeConfiguration(void)
+void Configuration::writeConfiguration()
 {
     // Write the valid configuration flag
     configuration->setValue("version", settings.version);
@@ -96,7 +96,7 @@ void Configuration::writeConfiguration(void)
     configuration->sync();
 }
 
-void Configuration::readConfiguration(void)
+void Configuration::readConfiguration()
 {
     qDebug() << "Configuration::readConfiguration(): Reading configuration from" << configuration->fileName();
 
@@ -138,7 +138,7 @@ void Configuration::readConfiguration(void)
     configuration->endGroup();
 }
 
-void Configuration::setDefault(void)
+void Configuration::setDefault()
 {
     // Set up the default values
     settings.version = SETTINGSVERSION;
@@ -249,7 +249,7 @@ void Configuration::setCaptureDirectory(QString captureDirectory)
     settings.capture.captureDirectory = captureDirectory;
 }
 
-QString Configuration::getCaptureDirectory(void)
+QString Configuration::getCaptureDirectory()
 {
     return settings.capture.captureDirectory;
 }
@@ -259,7 +259,7 @@ void Configuration::setCaptureFormat(CaptureFormat captureFormat)
     settings.capture.captureFormat = captureFormat;
 }
 
-Configuration::CaptureFormat Configuration::getCaptureFormat(void)
+Configuration::CaptureFormat Configuration::getCaptureFormat()
 {
     return settings.capture.captureFormat;
 }
@@ -270,7 +270,7 @@ void Configuration::setUsbVid(quint16 vid)
     settings.usb.vid = vid;
 }
 
-quint16 Configuration::getUsbVid(void)
+quint16 Configuration::getUsbVid()
 {
     return settings.usb.vid;
 }
@@ -279,7 +279,7 @@ void Configuration::setUsbPid(quint16 pid)
     settings.usb.pid = pid;
 }
 
-quint16 Configuration::getUsbPid(void)
+quint16 Configuration::getUsbPid()
 {
     return settings.usb.pid;
 }
@@ -290,7 +290,7 @@ void Configuration::setSerialSpeed(SerialSpeeds serialSpeed)
     settings.pic.serialSpeed = serialSpeed;
 }
 
-Configuration::SerialSpeeds Configuration::getSerialSpeed(void)
+Configuration::SerialSpeeds Configuration::getSerialSpeed()
 {
     return settings.pic.serialSpeed;
 }
@@ -300,7 +300,7 @@ void Configuration::setSerialDevice(QString serialDevice)
     settings.pic.serialDevice = serialDevice;
 }
 
-QString Configuration::getSerialDevice(void)
+QString Configuration::getSerialDevice()
 {
     return settings.pic.serialDevice;
 }
@@ -310,7 +310,7 @@ void Configuration::setKeyLock(bool keyLock)
     settings.pic.keyLock = keyLock;
 }
 
-bool Configuration::getKeyLock(void)
+bool Configuration::getKeyLock()
 {
     return settings.pic.keyLock;
 }
@@ -321,7 +321,7 @@ void Configuration::setAmplitudeEnabled(bool amplitudeEnabled)
     settings.ui.amplitudeEnabled = amplitudeEnabled;
 }
 
-bool Configuration::getAmplitudeEnabled(void)
+bool Configuration::getAmplitudeEnabled()
 {
     return settings.ui.amplitudeEnabled;
 }
@@ -331,7 +331,7 @@ void Configuration::setGraphType(GraphType graphType)
     settings.ui.graphType = graphType;
 }
 
-Configuration::GraphType Configuration::getGraphType(void)
+Configuration::GraphType Configuration::getGraphType()
 {
     return settings.ui.graphType;
 }
@@ -342,7 +342,7 @@ void Configuration::setMainWindowGeometry(QByteArray mainWindowGeometry)
     settings.windows.mainWindowGeometry = mainWindowGeometry;
 }
 
-QByteArray Configuration::getMainWindowGeometry(void)
+QByteArray Configuration::getMainWindowGeometry()
 {
     return settings.windows.mainWindowGeometry;
 }
@@ -352,7 +352,7 @@ void Configuration::setPlayerRemoteDialogGeometry(QByteArray playerRemoteDialogG
     settings.windows.playerRemoteDialogGeometry = playerRemoteDialogGeometry;
 }
 
-QByteArray Configuration::getPlayerRemoteDialogGeometry(void)
+QByteArray Configuration::getPlayerRemoteDialogGeometry()
 {
     return settings.windows.playerRemoteDialogGeometry;
 }
@@ -362,7 +362,7 @@ void Configuration::setAdvancedNamingDialogGeometry(QByteArray advancedNamingDia
     settings.windows.advancedNamingDialogGeometry = advancedNamingDialogGeometry;
 }
 
-QByteArray Configuration::getAdvancedNamingDialogGeometry(void)
+QByteArray Configuration::getAdvancedNamingDialogGeometry()
 {
     return settings.windows.advancedNamingDialogGeometry;
 }
@@ -372,7 +372,7 @@ void Configuration::setAutomaticCaptureDialogGeometry(QByteArray automaticCaptur
     settings.windows.automaticCaptureDialogGeometry = automaticCaptureDialogGeometry;
 }
 
-QByteArray Configuration::getAutomaticCaptureDialogGeometry(void)
+QByteArray Configuration::getAutomaticCaptureDialogGeometry()
 {
     return settings.windows.automaticCaptureDialogGeometry;
 }
@@ -382,7 +382,7 @@ void Configuration::setConfigurationDialogGeometry(QByteArray configurationDialo
     settings.windows.configurationDialogGeometry = configurationDialogGeometry;
 }
 
-QByteArray Configuration::getConfigurationDialogGeometry(void)
+QByteArray Configuration::getConfigurationDialogGeometry()
 {
     return settings.windows.configurationDialogGeometry;
 }

--- a/Linux-Application/DomesdayDuplicator/configuration.cpp
+++ b/Linux-Application/DomesdayDuplicator/configuration.cpp
@@ -66,8 +66,8 @@ void Configuration::writeConfiguration()
 
     // UI
     configuration->beginGroup("ui");
-    configuration->setValue("amplitudeEnabled", settings.ui.amplitudeEnabled);
-    configuration->setValue("graphType", convertGraphTypeToInt(settings.ui.graphType));
+    configuration->setValue("amplitudeEnabled", settings.ui.amplitudeLabelEnabled);
+    configuration->setValue("graphType", settings.ui.amplitudeChartEnabled ? 1 : 0);
     configuration->endGroup();
 
     // USB
@@ -111,8 +111,8 @@ void Configuration::readConfiguration()
 
     // UI
     configuration->beginGroup("ui");
-    settings.ui.graphType = convertIntToGraphType(configuration->value("graphType").toInt());
-    settings.ui.amplitudeEnabled = configuration->value("amplitudeEnabled").toBool();
+    settings.ui.amplitudeLabelEnabled = configuration->value("amplitudeEnabled").toBool();
+    settings.ui.amplitudeChartEnabled = configuration->value("graphType").toInt() > 0;
     configuration->endGroup();
 
     // USB
@@ -148,8 +148,8 @@ void Configuration::setDefault()
     settings.capture.captureFormat = CaptureFormat::tenBitPacked;
 
     // UI
-    settings.ui.graphType = GraphType::noGraph;
-    settings.ui.amplitudeEnabled = false;
+    settings.ui.amplitudeLabelEnabled = false;
+    settings.ui.amplitudeChartEnabled = false;
 
     // USB
     settings.usb.vid = 0x1D50;
@@ -193,26 +193,6 @@ Configuration::CaptureFormat Configuration::convertIntToCaptureFormat(qint32 cap
 
     // Default to 10 bit packed
     return CaptureFormat::tenBitPacked;
-}
-
-// Enum conversion from GraphType to int
-qint32 Configuration::convertGraphTypeToInt(GraphType graphType)
-{
-    if (graphType == GraphType::noGraph) return 0;
-    if (graphType == GraphType::QCPMean) return 1;
-
-    // Default to 0
-    return 0;
-}
-
-// Enum conversion from int to GraphType
-Configuration::GraphType Configuration::convertIntToGraphType(qint32 graphInt)
-{
-    if (graphInt == 0) return GraphType::noGraph;
-    if (graphInt == 1) return GraphType::QCPMean;
-
-    // Default to no graph
-    return GraphType::noGraph;
 }
 
 // Enum conversion from serial speed to int
@@ -316,24 +296,24 @@ bool Configuration::getKeyLock()
 }
 
 // UI settings
-void Configuration::setAmplitudeEnabled(bool amplitudeEnabled)
+void Configuration::setAmplitudeLabelEnabled(bool enabled)
 {
-    settings.ui.amplitudeEnabled = amplitudeEnabled;
+    settings.ui.amplitudeLabelEnabled = enabled;
 }
 
-bool Configuration::getAmplitudeEnabled()
+bool Configuration::getAmplitudeLabelEnabled()
 {
-    return settings.ui.amplitudeEnabled;
+    return settings.ui.amplitudeLabelEnabled;
 }
 
-void Configuration::setGraphType(GraphType graphType)
+void Configuration::setAmplitudeChartEnabled(bool enabled)
 {
-    settings.ui.graphType = graphType;
+    settings.ui.amplitudeChartEnabled = enabled;
 }
 
-Configuration::GraphType Configuration::getGraphType()
+bool Configuration::getAmplitudeChartEnabled()
 {
-    return settings.ui.graphType;
+    return settings.ui.amplitudeChartEnabled;
 }
 
 // Windows

--- a/Linux-Application/DomesdayDuplicator/configuration.h
+++ b/Linux-Application/DomesdayDuplicator/configuration.h
@@ -64,41 +64,41 @@ public:
 
     explicit Configuration(QObject *parent = nullptr);
 
-    void writeConfiguration(void);
-    void readConfiguration(void);
+    void writeConfiguration();
+    void readConfiguration();
 
     // Get and set methods
-    void setDefault(void);
+    void setDefault();
 
     void setCaptureDirectory(QString captureDirectory);
-    QString getCaptureDirectory(void);
+    QString getCaptureDirectory();
     void setCaptureFormat(CaptureFormat captureFormat);
-    CaptureFormat getCaptureFormat(void);
+    CaptureFormat getCaptureFormat();
     void setUsbVid(quint16 vid);
-    quint16 getUsbVid(void);
+    quint16 getUsbVid();
     void setUsbPid(quint16 pid);
-    quint16 getUsbPid(void);
+    quint16 getUsbPid();
     void setSerialSpeed(SerialSpeeds serialSpeed);
-    SerialSpeeds getSerialSpeed(void);
+    SerialSpeeds getSerialSpeed();
     void setSerialDevice(QString serialDevice);
-    QString getSerialDevice(void);
+    QString getSerialDevice();
     void setKeyLock(bool keyLock);
-    bool getKeyLock(void);
+    bool getKeyLock();
     void setGraphType(GraphType graphType);
-    GraphType getGraphType(void);
-    bool getAmplitudeEnabled(void);
+    GraphType getGraphType();
+    bool getAmplitudeEnabled();
     void setAmplitudeEnabled(bool amplitudeEnabled);
 
     void setMainWindowGeometry(QByteArray mainWindowGeometry);
-    QByteArray getMainWindowGeometry(void);
+    QByteArray getMainWindowGeometry();
     void setPlayerRemoteDialogGeometry(QByteArray playerRemoteDialogGeometry);
-    QByteArray getPlayerRemoteDialogGeometry(void);
+    QByteArray getPlayerRemoteDialogGeometry();
     void setAdvancedNamingDialogGeometry(QByteArray advancedNamingDialogGeometry);
-    QByteArray getAdvancedNamingDialogGeometry(void);
+    QByteArray getAdvancedNamingDialogGeometry();
     void setAutomaticCaptureDialogGeometry(QByteArray automaticCaptureDialogGeometry);
-    QByteArray getAutomaticCaptureDialogGeometry(void);
+    QByteArray getAutomaticCaptureDialogGeometry();
     void setConfigurationDialogGeometry(QByteArray configurationDialogGeometry);
-    QByteArray getConfigurationDialogGeometry(void);
+    QByteArray getConfigurationDialogGeometry();
 
 signals:
 

--- a/Linux-Application/DomesdayDuplicator/configuration.h
+++ b/Linux-Application/DomesdayDuplicator/configuration.h
@@ -78,6 +78,10 @@ public:
     QString getSerialDevice();
     void setKeyLock(bool keyLock);
     bool getKeyLock();
+    bool getPerSideNotesEnabled();
+    void setPerSideNotesEnabled(bool enabled);
+    bool getPerSideMintEnabled();
+    void setPerSideMintEnabled(bool enabled);
     bool getAmplitudeLabelEnabled();
     void setAmplitudeLabelEnabled(bool enabled);
     bool getAmplitudeChartEnabled();
@@ -120,6 +124,8 @@ private:
     };
 
     struct Ui {
+        bool perSideNotesEnabled;
+        bool perSideMintEnabled;
         bool amplitudeLabelEnabled;
         bool amplitudeChartEnabled;
     };

--- a/Linux-Application/DomesdayDuplicator/configuration.h
+++ b/Linux-Application/DomesdayDuplicator/configuration.h
@@ -56,12 +56,6 @@ public:
         autoDetect,
     };
 
-    // Define the possible amplitude graph types
-    enum GraphType {
-        noGraph,
-        QCPMean,
-    };
-
     explicit Configuration(QObject *parent = nullptr);
 
     void writeConfiguration();
@@ -84,10 +78,10 @@ public:
     QString getSerialDevice();
     void setKeyLock(bool keyLock);
     bool getKeyLock();
-    void setGraphType(GraphType graphType);
-    GraphType getGraphType();
-    bool getAmplitudeEnabled();
-    void setAmplitudeEnabled(bool amplitudeEnabled);
+    bool getAmplitudeLabelEnabled();
+    void setAmplitudeLabelEnabled(bool enabled);
+    bool getAmplitudeChartEnabled();
+    void setAmplitudeChartEnabled(bool enabled);
 
     void setMainWindowGeometry(QByteArray mainWindowGeometry);
     QByteArray getMainWindowGeometry();
@@ -108,7 +102,7 @@ private:
     QSettings *configuration;
 
     // Note: Configuration is organised by the following top-level labels
-    // Capture, USB, PIC (player integrated capture), UI (includes optional UI features [currently RF amplitude RMS and graphing])
+    // Capture, USB, PIC (player integrated capture), UI
     struct Capture {
         QString captureDirectory;
         CaptureFormat captureFormat;
@@ -126,8 +120,8 @@ private:
     };
 
     struct Ui {
-        GraphType graphType;
-        bool amplitudeEnabled;
+        bool amplitudeLabelEnabled;
+        bool amplitudeChartEnabled;
     };
 
     // Window geometry and settings
@@ -152,8 +146,6 @@ private:
     CaptureFormat convertIntToCaptureFormat(qint32 captureInt);
     qint32 convertSerialSpeedsToInt(SerialSpeeds serialSpeeds);
     SerialSpeeds convertIntToSerialSpeeds(qint32 serialInt);
-    qint32 convertGraphTypeToInt(GraphType graphType);
-    GraphType convertIntToGraphType(qint32 graphInt);
 };
 
 #endif // CONFIGURATION_H

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
@@ -63,14 +63,8 @@ void ConfigurationDialog::loadConfiguration(Configuration *configuration)
     }
 
     // Amplitude
-    ui->amplitudeProcessingCheckBox->setChecked(configuration->getAmplitudeEnabled());
-
-    // Graph Type
-    if(configuration->getGraphType() == Configuration::GraphType::QCPMean) {
-        ui->amplitudeGraphRadioButton->setChecked(true);
-    } else {
-        ui->noGraphButton->setChecked(true);
-    }
+    ui->amplitudeLabelCheckBox->setChecked(configuration->getAmplitudeLabelEnabled());
+    ui->amplitudeChartCheckBox->setChecked(configuration->getAmplitudeChartEnabled());
 
     // USB
     ui->vendorIdLineEdit->setText(QString::number(configuration->getUsbVid()));
@@ -147,12 +141,8 @@ void ConfigurationDialog::saveConfiguration(Configuration *configuration)
     else configuration->setKeyLock(false);
 
     // Amplitude
-    if (ui->amplitudeProcessingCheckBox->isChecked()) configuration->setAmplitudeEnabled(true);
-    else configuration->setAmplitudeEnabled(false);
-
-    // Graph
-    if (ui->noGraphButton->isChecked()) configuration->setGraphType(Configuration::noGraph);
-    else if (ui->amplitudeGraphRadioButton->isChecked()) configuration->setGraphType(Configuration::QCPMean);
+    configuration->setAmplitudeLabelEnabled(ui->amplitudeLabelCheckBox->isChecked());
+    configuration->setAmplitudeChartEnabled(ui->amplitudeChartCheckBox->isChecked());
 
     // Save the configuration to disk
     configuration->writeConfiguration();

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
@@ -195,5 +195,8 @@ void ConfigurationDialog::on_buttonBox_clicked(QAbstractButton *button)
 
         ui->serialDeviceComboBox->setCurrentIndex(0);
         ui->serialSpeedComboBox->setCurrentIndex(ui->serialSpeedComboBox->findData(Configuration::SerialSpeeds::autoDetect));
+
+        ui->amplitudeLabelCheckBox->setChecked(false);
+        ui->amplitudeChartCheckBox->setChecked(false);
     }
 }

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
@@ -62,10 +62,6 @@ void ConfigurationDialog::loadConfiguration(Configuration *configuration)
         ui->saveAs10BitCdRadioButton->setChecked(true);
     }
 
-    // Amplitude
-    ui->amplitudeLabelCheckBox->setChecked(configuration->getAmplitudeLabelEnabled());
-    ui->amplitudeChartCheckBox->setChecked(configuration->getAmplitudeChartEnabled());
-
     // USB
     ui->vendorIdLineEdit->setText(QString::number(configuration->getUsbVid()));
     ui->productIdLineEdit->setText(QString::number(configuration->getUsbPid()));
@@ -112,6 +108,10 @@ void ConfigurationDialog::loadConfiguration(Configuration *configuration)
 
     // Keylock flag
     ui->keyLockCheckBox->setChecked(configuration->getKeyLock());
+
+    // Amplitude
+    ui->amplitudeLabelCheckBox->setChecked(configuration->getAmplitudeLabelEnabled());
+    ui->amplitudeChartCheckBox->setChecked(configuration->getAmplitudeChartEnabled());
 }
 
 // Save the configuration settings from the UI widgets

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.cpp
@@ -109,6 +109,10 @@ void ConfigurationDialog::loadConfiguration(Configuration *configuration)
     // Keylock flag
     ui->keyLockCheckBox->setChecked(configuration->getKeyLock());
 
+    // Advanced naming
+    ui->perSideNotesCheckBox->setChecked(configuration->getPerSideNotesEnabled());
+    ui->perSideMintCheckBox->setChecked(configuration->getPerSideMintEnabled());
+
     // Amplitude
     ui->amplitudeLabelCheckBox->setChecked(configuration->getAmplitudeLabelEnabled());
     ui->amplitudeChartCheckBox->setChecked(configuration->getAmplitudeChartEnabled());
@@ -139,6 +143,10 @@ void ConfigurationDialog::saveConfiguration(Configuration *configuration)
     // KeyLock
     if (ui->keyLockCheckBox->isChecked()) configuration->setKeyLock(true);
     else configuration->setKeyLock(false);
+
+    // Advanced naming
+    configuration->setPerSideNotesEnabled(ui->perSideNotesCheckBox->isChecked());
+    configuration->setPerSideMintEnabled(ui->perSideMintCheckBox->isChecked());
 
     // Amplitude
     configuration->setAmplitudeLabelEnabled(ui->amplitudeLabelCheckBox->isChecked());
@@ -195,6 +203,9 @@ void ConfigurationDialog::on_buttonBox_clicked(QAbstractButton *button)
 
         ui->serialDeviceComboBox->setCurrentIndex(0);
         ui->serialSpeedComboBox->setCurrentIndex(ui->serialSpeedComboBox->findData(Configuration::SerialSpeeds::autoDetect));
+
+        ui->perSideNotesCheckBox->setChecked(false);
+        ui->perSideMintCheckBox->setChecked(false);
 
         ui->amplitudeLabelCheckBox->setChecked(false);
         ui->amplitudeChartCheckBox->setChecked(false);

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.h
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.h
@@ -52,7 +52,7 @@ public:
     void saveConfiguration(Configuration *configuration);
 
 signals:
-    void configurationChanged(void);
+    void configurationChanged();
 
 private slots:
     void on_captureDirectoryPushButton_clicked();

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Preferences</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="preferencesVerticalLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="minimumSize">
@@ -35,7 +35,7 @@
       <attribute name="title">
        <string>Capture</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="captureVerticalLayout">
        <item>
         <layout class="QHBoxLayout" name="captureDirectoryHorizontalLayout">
          <item>
@@ -138,7 +138,7 @@
       <attribute name="title">
        <string>USB</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="usbVerticalLayout">
        <item>
         <layout class="QGridLayout" name="usbDeviceGridLayout">
          <item row="0" column="0">
@@ -212,7 +212,7 @@
       <attribute name="title">
        <string>Player Control</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="playerControlVerticalLayout">
        <item>
         <layout class="QGridLayout" name="serialDeviceGridLayout">
          <item row="0" column="0">
@@ -311,7 +311,7 @@
       <attribute name="title">
        <string>User Interface</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="userInterfaceVerticalLayout">
        <item>
         <widget class="QLabel" name="advancedNamingLabel">
          <property name="text">

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -313,6 +313,43 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
+        <widget class="QLabel" name="advancedNamingLabel">
+         <property name="text">
+          <string>Advanced capture naming:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="perSideNotesCheckBox">
+         <property name="text">
+          <string>Reset notes when disc side changes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="perSideMintCheckBox">
+         <property name="text">
+          <string>Reset mint marks when disc side changes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_8">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>12</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <widget class="QLabel" name="amplitudeLabel">
          <property name="text">
           <string>RF signal amplitude display:</string>
@@ -383,6 +420,8 @@
   <tabstop>serialDeviceComboBox</tabstop>
   <tabstop>serialSpeedComboBox</tabstop>
   <tabstop>keyLockCheckBox</tabstop>
+  <tabstop>perSideNotesCheckBox</tabstop>
+  <tabstop>perSideMintCheckBox</tabstop>
   <tabstop>amplitudeLabelCheckBox</tabstop>
   <tabstop>amplitudeChartCheckBox</tabstop>
  </tabstops>

--- a/Linux-Application/DomesdayDuplicator/configurationdialog.ui
+++ b/Linux-Application/DomesdayDuplicator/configurationdialog.ui
@@ -315,7 +315,7 @@
        <item>
         <widget class="QLabel" name="amplitudeLabel">
          <property name="text">
-          <string>RF Signal Amplitude Processing:</string>
+          <string>RF signal amplitude display:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -323,78 +323,16 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_7">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>12</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="textLabelOptionsLabel">
+        <widget class="QCheckBox" name="amplitudeLabelCheckBox">
          <property name="text">
-          <string>Text Label Options (Low CPU usage):</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          <string>Show RMS amplitude as number (low CPU usage)</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="amplitudeProcessingCheckBox">
+        <widget class="QCheckBox" name="amplitudeChartCheckBox">
          <property name="text">
-          <string>RMS (Average)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>12</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="graphingOptionsLabel">
-         <property name="text">
-          <string>Graphing Options (Higher CPU usage):</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="amplitudeGraphRadioButton">
-         <property name="text">
-          <string>Mean Amplitude (QCP)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="noGraphButton">
-         <property name="text">
-          <string>None</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
+          <string>Show RMS amplitude as chart (higher CPU usage)</string>
          </property>
         </widget>
        </item>
@@ -445,9 +383,8 @@
   <tabstop>serialDeviceComboBox</tabstop>
   <tabstop>serialSpeedComboBox</tabstop>
   <tabstop>keyLockCheckBox</tabstop>
-  <tabstop>amplitudeProcessingCheckBox</tabstop>
-  <tabstop>amplitudeGraphRadioButton</tabstop>
-  <tabstop>noGraphButton</tabstop>
+  <tabstop>amplitudeLabelCheckBox</tabstop>
+  <tabstop>amplitudeChartCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -182,7 +182,7 @@ MainWindow::~MainWindow()
 // Signal handlers ----------------------------------------------------------------------------------------------------
 
 // USB device attached signal handler
-void MainWindow::deviceAttachedSignalHandler(void)
+void MainWindow::deviceAttachedSignalHandler()
 {
     qDebug() << "MainWindow::deviceAttachedSignalHandler(): Domesday Duplicator USB device has been attached";
 
@@ -203,7 +203,7 @@ void MainWindow::deviceAttachedSignalHandler(void)
 }
 
 // USB device detached signal handler
-void MainWindow::deviceDetachedSignalHandler(void)
+void MainWindow::deviceDetachedSignalHandler()
 {
     qDebug() << "MainWindow::deviceAttachedSignalHandler(): Domesday Duplicator USB device has been detached";
 
@@ -221,7 +221,7 @@ void MainWindow::deviceDetachedSignalHandler(void)
 }
 
 // Configuration changed signal handler
-void MainWindow::configurationChangedSignalHandler(void)
+void MainWindow::configurationChangedSignalHandler()
 {
     qDebug() << "MainWindow::configurationChangedSignalHandler(): Configuration has been changed";
 
@@ -376,7 +376,7 @@ void MainWindow::remoteControlSearchSignalHandler(qint32 position, PlayerRemoteD
 }
 
 // Update capture duration timer signal handler
-void MainWindow::updateCaptureDuration(void)
+void MainWindow::updateCaptureDuration()
 {
     // Add a second to the capture time and update the label
     captureElapsedTime = captureElapsedTime.addSecs(1);
@@ -431,13 +431,13 @@ void MainWindow::startAutomaticCaptureDialogSignalHandler(AutomaticCaptureDialog
 }
 
 // Automatic capture dialogue signals that capture should stop
-void MainWindow::stopAutomaticCaptureDialogSignalHandler(void)
+void MainWindow::stopAutomaticCaptureDialogSignalHandler()
 {
     playerControl->stopAutomaticCapture();
 }
 
 // Update the automatic capture status (called by a timer)
-void MainWindow::updateAutomaticCaptureStatus(void)
+void MainWindow::updateAutomaticCaptureStatus()
 {
     automaticCaptureDialog->updateStatus(playerControl->getAutomaticCaptureStatus());
 }
@@ -458,21 +458,21 @@ void MainWindow::automaticCaptureCompleteSignalHandler(bool success)
 }
 
 // Handle the start capture signal from the player control object
-void MainWindow::startCaptureSignalHandler(void)
+void MainWindow::startCaptureSignalHandler()
 {
     qDebug() << "MainWindow::startCaptureSignalHandler(): Got start capture signal from player control";
     if (!isCaptureRunning) on_capturePushButton_clicked();
 }
 
 // Handle the stop capture signal from the player control object
-void MainWindow::stopCaptureSignalHandler(void)
+void MainWindow::stopCaptureSignalHandler()
 {
     qDebug() << "MainWindow::stopCaptureSignalHandler(): Got stop capture signal from player control";
     if (isCaptureRunning) on_capturePushButton_clicked();
 }
 
 // Signal handler for player connected signal from player control
-void MainWindow::playerConnectedSignalHandler(void)
+void MainWindow::playerConnectedSignalHandler()
 {
     qDebug() << "MainWindow::playerConnectedSignalHandler(): Received player connected signal";
     // Enable remote control dialogue
@@ -485,7 +485,7 @@ void MainWindow::playerConnectedSignalHandler(void)
 }
 
 // Signal handler for player disconnected signal from player control
-void MainWindow::playerDisconnectedSignalHandler(void)
+void MainWindow::playerDisconnectedSignalHandler()
 {
     qDebug() << "MainWindow::playerConnectedSignalHandler(): Received player disconnected signal";
     // Disable remote control dialogue
@@ -498,7 +498,7 @@ void MainWindow::playerDisconnectedSignalHandler(void)
 }
 
 // Update the capture statistics labels
-void MainWindow::updateCaptureStatistics(void)
+void MainWindow::updateCaptureStatistics()
 {
     ui->numberOfTransfersLabel->setText(QString::number(usbDevice->getNumberOfTransfers()));
 
@@ -514,7 +514,7 @@ void MainWindow::updateCaptureStatistics(void)
 }
 
 // Update the player control labels
-void MainWindow::updatePlayerControlInformation(void)
+void MainWindow::updatePlayerControlInformation()
 {
     if (!playerControl->getSerialBaudRate().isEmpty()) {
         ui->playerPortLabel->setText(configuration->getSerialDevice() + " @ " + playerControl->getSerialBaudRate() + " bps");
@@ -544,7 +544,7 @@ void MainWindow::updatePlayerControlInformation(void)
 }
 
 // Update the storage information labels
-void MainWindow::updateStorageInformation(void)
+void MainWindow::updateStorageInformation()
 {
     storageInfo->refresh();
     if (storageInfo->isValid()) {
@@ -575,7 +575,7 @@ void MainWindow::updateStorageInformation(void)
 
 }
 
-void MainWindow::startPlayerControl(void)
+void MainWindow::startPlayerControl()
 {
     // Get the configured serial speed
     PlayerCommunication::SerialSpeed serialSpeed = PlayerCommunication::SerialSpeed::bps9600;
@@ -753,7 +753,7 @@ void MainWindow::on_limitDurationCheckBox_stateChanged(int arg1)
 }
 
 // Transfer failed notification signal handler
-void MainWindow::transferFailedSignalHandler(void)
+void MainWindow::transferFailedSignalHandler()
 {
     // Stop capture - something has gone wrong
     usbDevice->stopCapture();
@@ -770,7 +770,7 @@ void MainWindow::transferFailedSignalHandler(void)
 }
 
 // Update the GUI when capture starts
-void MainWindow::updateGuiForCaptureStart(void)
+void MainWindow::updateGuiForCaptureStart()
 {
     // Disable functions during capture
     ui->capturePushButton->setText(tr("Stop Capture"));
@@ -786,7 +786,7 @@ void MainWindow::updateGuiForCaptureStart(void)
 }
 
 // Update the GUI when capture stops, and flip rename var back to false
-void MainWindow::updateGuiForCaptureStop(void)
+void MainWindow::updateGuiForCaptureStop()
 {
     // Disable functions after capture
     if (ui->actionTest_mode->isChecked()) ui->capturePushButton->setText(tr("Test data capture"));
@@ -797,7 +797,7 @@ void MainWindow::updateGuiForCaptureStop(void)
 }
 
 // Update the player remote control dialogue
-void MainWindow::updatePlayerRemoteDialog(void)
+void MainWindow::updatePlayerRemoteDialog()
 {
     switch(remoteDisplayState) {
     case PlayerCommunication::DisplayState::off:
@@ -840,13 +840,13 @@ void MainWindow::updatePlayerRemoteDialog(void)
 }
 
 // Timer callback to update amplitude display
-void MainWindow::updateAmplitudeLabel(void)
+void MainWindow::updateAmplitudeLabel()
 {
     ui->meanAmplitudeLabel->setText(QString::number(ui->am->getMeanAmplitude(), 'f', 3));
 }
 
 // Update amplitude UI elements
-void MainWindow::updateAmplitudeUI(void)
+void MainWindow::updateAmplitudeUI()
 {
     // If any amplitude display is enabled, capture amplitude data
     if (configuration->getAmplitudeEnabled() || configuration->getGraphType() != Configuration::GraphType::noGraph) {

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -849,14 +849,14 @@ void MainWindow::updateAmplitudeLabel()
 void MainWindow::updateAmplitudeUI()
 {
     // If any amplitude display is enabled, capture amplitude data
-    if (configuration->getAmplitudeEnabled() || configuration->getGraphType() != Configuration::GraphType::noGraph) {
+    if (configuration->getAmplitudeLabelEnabled() || configuration->getAmplitudeChartEnabled()) {
         connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(updateBuffer()));
     } else {
         disconnect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(updateBuffer()));
     }
 
     // Update amplitude label, driven by timer
-    if (configuration->getAmplitudeEnabled()) {
+    if (configuration->getAmplitudeLabelEnabled()) {
         ui->meanAmplitudeLabel->setText("0.000");
         connect(amplitudeTimer, SIGNAL(timeout()), this, SLOT(updateAmplitudeLabel()));
     } else {
@@ -865,7 +865,7 @@ void MainWindow::updateAmplitudeUI()
     }
 
     // Update amplitude graph
-    if (configuration->getGraphType() == Configuration::GraphType::QCPMean) {
+    if (configuration->getAmplitudeChartEnabled()) {
         ui->am->setVisible(true);
         connect(amplitudeTimer, SIGNAL(timeout()), ui->am, SLOT(plotGraph()));
     } else {

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -234,6 +234,10 @@ void MainWindow::configurationChangedSignalHandler()
     // Update the target directory for the storage information
     storageInfo->setPath(configuration->getCaptureDirectory());
 
+    // Update advanced naming UI
+    advancedNamingDialog->setPerSideNotesEnabled(configuration->getPerSideNotesEnabled());
+    advancedNamingDialog->setPerSideMintEnabled(configuration->getPerSideMintEnabled());
+
     // Update amplitude UI
     updateAmplitudeUI();
 }

--- a/Linux-Application/DomesdayDuplicator/mainwindow.h
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.h
@@ -58,30 +58,30 @@ public:
     ~MainWindow();
 
 private slots:
-    void deviceAttachedSignalHandler(void);
-    void deviceDetachedSignalHandler(void);
-    void configurationChangedSignalHandler(void);
+    void deviceAttachedSignalHandler();
+    void deviceDetachedSignalHandler();
+    void configurationChangedSignalHandler();
     void remoteControlCommandSignalHandler(PlayerRemoteDialog::RemoteButtons button);
     void remoteControlSearchSignalHandler(qint32 position, PlayerRemoteDialog::PositionMode positionMode);
     void startAutomaticCaptureDialogSignalHandler(AutomaticCaptureDialog::CaptureType captureType,
                                                               qint32 startAddress, qint32 endAddress,
                                                               AutomaticCaptureDialog::DiscType discTypeParam);
-    void stopAutomaticCaptureDialogSignalHandler(void);
-    void updateAutomaticCaptureStatus(void);
+    void stopAutomaticCaptureDialogSignalHandler();
+    void updateAutomaticCaptureStatus();
     void automaticCaptureCompleteSignalHandler(bool success);
 
-    void playerConnectedSignalHandler(void);
-    void playerDisconnectedSignalHandler(void);
+    void playerConnectedSignalHandler();
+    void playerDisconnectedSignalHandler();
 
-    void startCaptureSignalHandler(void);
-    void stopCaptureSignalHandler(void);
+    void startCaptureSignalHandler();
+    void stopCaptureSignalHandler();
 
-    void updateCaptureStatistics(void);
-    void updatePlayerControlInformation(void);
-    void transferFailedSignalHandler(void);
-    void updateCaptureDuration(void);
-    void updateStorageInformation(void);
-    void updateAmplitudeLabel(void);
+    void updateCaptureStatistics();
+    void updatePlayerControlInformation();
+    void transferFailedSignalHandler();
+    void updateCaptureDuration();
+    void updateStorageInformation();
+    void updateAmplitudeLabel();
 
     void on_actionExit_triggered();
     void on_actionTest_mode_toggled(bool arg1);
@@ -125,15 +125,15 @@ private:
     qint32 remoteSpeed;
     PlayerCommunication::ChapterFrameMode remoteChapterFrameMode;
 
-    void updateGuiForCaptureStart(void);
-    void updateGuiForCaptureStop(void);
-    void startPlayerControl(void);
-    void updatePlayerRemoteDialog(void);
-    void updateAmplitudeUI(void);
+    void updateGuiForCaptureStart();
+    void updateGuiForCaptureStop();
+    void startPlayerControl();
+    void updatePlayerRemoteDialog();
+    void updateAmplitudeUI();
 
 signals:
-    void plotAmplitude(void);
-    void bufferAmplitude(void);
+    void plotAmplitude();
+    void bufferAmplitude();
 };
 
 #endif // MAINWINDOW_H

--- a/Linux-Application/DomesdayDuplicator/playercommunication.cpp
+++ b/Linux-Application/DomesdayDuplicator/playercommunication.cpp
@@ -256,7 +256,7 @@ bool PlayerCommunication::connect(QString serialDevice, SerialSpeed serialSpeed)
 }
 
 // Disconnect from a LaserDisc player
-void PlayerCommunication::disconnect(void)
+void PlayerCommunication::disconnect()
 {
     qDebug() << "PlayerCommunication::disconnect(): Disconnecting from serial port";
     currentPlayerName = "";
@@ -268,7 +268,7 @@ void PlayerCommunication::disconnect(void)
 
 // Player command methods ---------------------------------------------------------------------------------------------
 
-PlayerCommunication::TrayState PlayerCommunication::getTrayState(void)
+PlayerCommunication::TrayState PlayerCommunication::getTrayState()
 {
     sendSerialCommand("?P\r"); // Player active mode request
     QString response = getSerialResponse(N_TIMEOUT);
@@ -282,27 +282,27 @@ PlayerCommunication::TrayState PlayerCommunication::getTrayState(void)
     return TrayState::closed;
 }
 
-PlayerCommunication::PlayerType PlayerCommunication::getPlayerType(void)
+PlayerCommunication::PlayerType PlayerCommunication::getPlayerType()
 {
     return currentPlayerType;
 }
 
-QString PlayerCommunication::getPlayerName(void)
+QString PlayerCommunication::getPlayerName()
 {
     return currentPlayerName;
 }
 
-QString PlayerCommunication::getPlayerVersionNumber(void)
+QString PlayerCommunication::getPlayerVersionNumber()
 {
     return currentPlayerVersionNumber;
 }
 
-PlayerCommunication::SerialSpeed PlayerCommunication::getSerialSpeed(void)
+PlayerCommunication::SerialSpeed PlayerCommunication::getSerialSpeed()
 {
     return currentSerialSpeed;
 }
 
-PlayerCommunication::PlayerState PlayerCommunication::getPlayerState(void)
+PlayerCommunication::PlayerState PlayerCommunication::getPlayerState()
 {
     sendSerialCommand("?P\r"); // Player active mode request
     QString response = getSerialResponse(N_TIMEOUT);
@@ -350,7 +350,7 @@ PlayerCommunication::PlayerState PlayerCommunication::getPlayerState(void)
 }
 
 // Return the current frame or -1 if communication fails
-qint32 PlayerCommunication::getCurrentFrame(void)
+qint32 PlayerCommunication::getCurrentFrame()
 {
     sendSerialCommand("?F\r");
     QString response = getSerialResponse(N_TIMEOUT);
@@ -363,7 +363,7 @@ qint32 PlayerCommunication::getCurrentFrame(void)
 }
 
 // Return the current timeCode or -1 if communication fails
-qint32 PlayerCommunication::getCurrentTimeCode(void)
+qint32 PlayerCommunication::getCurrentTimeCode()
 {
     sendSerialCommand("?F\r");
     QString response = getSerialResponse(N_TIMEOUT);
@@ -375,7 +375,7 @@ qint32 PlayerCommunication::getCurrentTimeCode(void)
     return timeCode;
 }
 
-PlayerCommunication::DiscType PlayerCommunication::getDiscType(void)
+PlayerCommunication::DiscType PlayerCommunication::getDiscType()
 {
     sendSerialCommand("?D\r");
     QString response = getSerialResponse(N_TIMEOUT);
@@ -399,13 +399,13 @@ PlayerCommunication::DiscType PlayerCommunication::getDiscType(void)
     return DiscType::unknownDiscType;
 }
 
-QString PlayerCommunication::getUserCode(void)
+QString PlayerCommunication::getUserCode()
 {
     sendSerialCommand("$Y\r");
     return getSerialResponse(N_TIMEOUT);
 }
 
-qint32 PlayerCommunication::getMaximumFrameNumber(void)
+qint32 PlayerCommunication::getMaximumFrameNumber()
 {
     sendSerialCommand("FR60000SE\r"); // Frame seek to impossible frame number
 
@@ -413,7 +413,7 @@ qint32 PlayerCommunication::getMaximumFrameNumber(void)
     return getCurrentFrame();
 }
 
-qint32 PlayerCommunication::getMaximumTimeCode(void)
+qint32 PlayerCommunication::getMaximumTimeCode()
 {
     sendSerialCommand("FR1595900SE\r"); // Frame seek to impossible time-code frame number
 

--- a/Linux-Application/DomesdayDuplicator/playercommunication.h
+++ b/Linux-Application/DomesdayDuplicator/playercommunication.h
@@ -119,19 +119,19 @@ public:
     };
 
     bool connect(QString serialDevice, SerialSpeed serialSpeed);
-    void disconnect(void);
-    PlayerType getPlayerType(void);
-    QString getPlayerName(void);
-    QString getPlayerVersionNumber(void);
-    SerialSpeed getSerialSpeed(void);
-    TrayState getTrayState(void);
-    PlayerState getPlayerState(void);
-    qint32 getCurrentFrame(void);
-    qint32 getCurrentTimeCode(void);
-    DiscType getDiscType(void);
-    QString getUserCode(void);
-    qint32 getMaximumFrameNumber(void);
-    qint32 getMaximumTimeCode(void);
+    void disconnect();
+    PlayerType getPlayerType();
+    QString getPlayerName();
+    QString getPlayerVersionNumber();
+    SerialSpeed getSerialSpeed();
+    TrayState getTrayState();
+    PlayerState getPlayerState();
+    qint32 getCurrentFrame();
+    qint32 getCurrentTimeCode();
+    DiscType getDiscType();
+    QString getUserCode();
+    qint32 getMaximumFrameNumber();
+    qint32 getMaximumTimeCode();
 
     bool setTrayState(TrayState trayState);
     bool setPlayerState(PlayerState playerState);

--- a/Linux-Application/DomesdayDuplicator/playercontrol.cpp
+++ b/Linux-Application/DomesdayDuplicator/playercontrol.cpp
@@ -189,23 +189,23 @@ void PlayerControl::run()
     emit playerDisconnected();
 }
 
-void PlayerControl::stop(void)
+void PlayerControl::stop()
 {
     qDebug() << "PlayerControl::stop(): Stopping player control thread";
     abort = true;
 }
 
-QString PlayerControl::getPlayerModelName(void)
+QString PlayerControl::getPlayerModelName()
 {
     return playerCommunication->getPlayerName();
 }
 
-QString PlayerControl::getPlayerVersionNumber(void)
+QString PlayerControl::getPlayerVersionNumber()
 {
     return playerCommunication->getPlayerVersionNumber();
 }
 
-QString PlayerControl::getSerialBaudRate(void)
+QString PlayerControl::getSerialBaudRate()
 {
     switch (playerCommunication->getSerialSpeed())
     {
@@ -224,7 +224,7 @@ QString PlayerControl::getSerialBaudRate(void)
 }
 
 // Returns a string that indicates the player's status
-QString PlayerControl::getPlayerStatusInformation(void)
+QString PlayerControl::getPlayerStatusInformation()
 {
     QString status;
 
@@ -244,7 +244,7 @@ QString PlayerControl::getPlayerStatusInformation(void)
 }
 
 // Returns a string that indicates the player's position (in the disc)
-QString PlayerControl::getPlayerPositionInformation(void)
+QString PlayerControl::getPlayerPositionInformation()
 {
     QString playerPosition;
 
@@ -282,7 +282,7 @@ QString PlayerControl::getPlayerPositionInformation(void)
 }
 
 // Get the disc type (CAV/CLV/unknown)
-PlayerCommunication::DiscType PlayerControl::getDiscType(void)
+PlayerCommunication::DiscType PlayerControl::getDiscType()
 {
     return discType;
 }
@@ -292,7 +292,7 @@ PlayerCommunication::DiscType PlayerControl::getDiscType(void)
 // This method takes commands and parameters from the queue and passes them to
 // the appropriate command processing method
 
-void PlayerControl::processCommandQueue(void)
+void PlayerControl::processCommandQueue()
 {
     // If the queue has commands in it, process one
     if (!commandQueue.isEmpty()) {
@@ -740,7 +740,7 @@ void PlayerControl::startAutomaticCapture(bool fromLeadIn, bool wholeDisc,
 }
 
 // Public method to stop an automatic capture
-void PlayerControl::stopAutomaticCapture(void)
+void PlayerControl::stopAutomaticCapture()
 {
     // Check automatic capture is running
     if (!acInProgress) {
@@ -755,19 +755,19 @@ void PlayerControl::stopAutomaticCapture(void)
 }
 
 // Public method to get the current automatic capture status
-QString PlayerControl::getAutomaticCaptureStatus(void)
+QString PlayerControl::getAutomaticCaptureStatus()
 {
     return acStatus;
 }
 
 // Public method to get the automatic capture error
-QString PlayerControl::getAutomaticCaptureError(void)
+QString PlayerControl::getAutomaticCaptureError()
 {
     return acErrorMessage;
 }
 
 // Private method for processing automatic capture
-void PlayerControl::processAutomaticCapture(void)
+void PlayerControl::processAutomaticCapture()
 {
     // Is automatic capture running?
     if (acInProgress) {
@@ -800,7 +800,7 @@ void PlayerControl::processAutomaticCapture(void)
 }
 
 // Automatic capture state machine - ac_start_state
-PlayerControl::AcStates PlayerControl::acStateStart(void)
+PlayerControl::AcStates PlayerControl::acStateStart()
 {
     AcStates nextState = AcStates::ac_start_state;
 
@@ -865,7 +865,7 @@ PlayerControl::AcStates PlayerControl::acStateStart(void)
 }
 
 // Automatic capture state machine - ac_getLength_state
-PlayerControl::AcStates PlayerControl::acStateGetLength(void)
+PlayerControl::AcStates PlayerControl::acStateGetLength()
 {
     AcStates nextState = AcStates::ac_start_state;
 
@@ -931,7 +931,7 @@ PlayerControl::AcStates PlayerControl::acStateGetLength(void)
 }
 
 // Automatic capture state machine - ac_spinDown_state
-PlayerControl::AcStates PlayerControl::acStateSpinDown(void)
+PlayerControl::AcStates PlayerControl::acStateSpinDown()
 {
     AcStates nextState = AcStates::ac_spinDown_state;
 
@@ -958,7 +958,7 @@ PlayerControl::AcStates PlayerControl::acStateSpinDown(void)
 }
 
 // Automatic capture state machine - ac_spinUpWithCapture_state
-PlayerControl::AcStates PlayerControl::acStateSpinUpWithCapture(void)
+PlayerControl::AcStates PlayerControl::acStateSpinUpWithCapture()
 {
     AcStates nextState = AcStates::ac_spinUpWithCapture_state;
 
@@ -995,7 +995,7 @@ PlayerControl::AcStates PlayerControl::acStateSpinUpWithCapture(void)
 }
 
 // Automatic capture state machine - ac_moveToStartPosition_state
-PlayerControl::AcStates PlayerControl::acStateMoveToStartPosition(void)
+PlayerControl::AcStates PlayerControl::acStateMoveToStartPosition()
 {
     AcStates nextState = AcStates::ac_moveToStartPosition_state;
 
@@ -1036,7 +1036,7 @@ PlayerControl::AcStates PlayerControl::acStateMoveToStartPosition(void)
 }
 
 // Automatic capture state machine - ac_playAndCapture_state
-PlayerControl::AcStates PlayerControl::acStatePlayAndCapture(void)
+PlayerControl::AcStates PlayerControl::acStatePlayAndCapture()
 {
     AcStates nextState = AcStates::ac_playAndCapture_state;
 
@@ -1068,7 +1068,7 @@ PlayerControl::AcStates PlayerControl::acStatePlayAndCapture(void)
 }
 
 // Automatic capture state machine - ac_waitForEndAddress_state
-PlayerControl::AcStates PlayerControl::acStateWaitForEndAddress(void)
+PlayerControl::AcStates PlayerControl::acStateWaitForEndAddress()
 {
     AcStates nextState = AcStates::ac_waitForEndAddress_state;
 
@@ -1153,7 +1153,7 @@ PlayerControl::AcStates PlayerControl::acStateWaitForEndAddress(void)
 }
 
 // Automatic capture state machine - ac_finished_state
-PlayerControl::AcStates PlayerControl::acStateFinished(void)
+PlayerControl::AcStates PlayerControl::acStateFinished()
 {
     AcStates nextState = AcStates::ac_finished_state;
 
@@ -1175,7 +1175,7 @@ PlayerControl::AcStates PlayerControl::acStateFinished(void)
 }
 
 // Automatic capture state machine - ac_cancelled_state
-PlayerControl::AcStates PlayerControl::acStateCancelled(void)
+PlayerControl::AcStates PlayerControl::acStateCancelled()
 {
     AcStates nextState = AcStates::ac_cancelled_state;
 
@@ -1202,7 +1202,7 @@ PlayerControl::AcStates PlayerControl::acStateCancelled(void)
 }
 
 // Automatic capture state machine - ac_error_state
-PlayerControl::AcStates PlayerControl::acStateError(void)
+PlayerControl::AcStates PlayerControl::acStateError()
 {
     AcStates nextState = AcStates::ac_error_state;
 

--- a/Linux-Application/DomesdayDuplicator/playercontrol.h
+++ b/Linux-Application/DomesdayDuplicator/playercontrol.h
@@ -46,17 +46,17 @@ public:
     explicit PlayerControl(QObject *parent = nullptr);
     ~PlayerControl() override;
 
-    void stop(void);
+    void stop();
     void configurePlayerCommunication(
             QString serialDevice,
             PlayerCommunication::SerialSpeed serialSpeed);
 
-    QString getPlayerModelName(void);
-    QString getPlayerVersionNumber(void);
-    QString getSerialBaudRate(void);
-    QString getPlayerStatusInformation(void);
-    QString getPlayerPositionInformation(void);
-    PlayerCommunication::DiscType getDiscType(void);
+    QString getPlayerModelName();
+    QString getPlayerVersionNumber();
+    QString getSerialBaudRate();
+    QString getPlayerStatusInformation();
+    QString getPlayerPositionInformation();
+    PlayerCommunication::DiscType getDiscType();
 
     // Commands
     enum Commands {
@@ -94,18 +94,18 @@ public:
     void startAutomaticCapture(bool fromLeadIn, bool wholeDisc,
                                      qint32 startAddress, qint32 endAddress,
                                      PlayerCommunication::DiscType discType, bool keyLock);
-    void stopAutomaticCapture(void);
-    QString getAutomaticCaptureStatus(void);
-    QString getAutomaticCaptureError(void);
+    void stopAutomaticCapture();
+    QString getAutomaticCaptureStatus();
+    QString getAutomaticCaptureError();
 
 signals:
-    void startCapture(void);
-    void stopCapture(void);
+    void startCapture();
+    void stopCapture();
     void playerControlError(QString);
     void automaticCaptureComplete(bool success);
 
-    void playerConnected(void);
-    void playerDisconnected(void);
+    void playerConnected();
+    void playerDisconnected();
 
 protected:
     void run() override;
@@ -163,7 +163,7 @@ private:
     QQueue<PlayerControl::Commands> commandQueue;
     QQueue<qint32> parameterQueue;
 
-    void processCommandQueue(void);
+    void processCommandQueue();
 
     void processSetTrayState(qint32 parameter1);
     void processSetPlayerState(qint32 parameter1);
@@ -180,19 +180,19 @@ private:
     void processSetKeyLock(qint32 parameter1);
     void processSetSpeed(qint32 parameter1);
 
-    void processAutomaticCapture(void);
+    void processAutomaticCapture();
 
     // Automatic capture state methods
-    PlayerControl::AcStates acStateStart(void);
-    PlayerControl::AcStates acStateGetLength(void);
-    PlayerControl::AcStates acStateSpinDown(void);
-    PlayerControl::AcStates acStateSpinUpWithCapture(void);
-    PlayerControl::AcStates acStateMoveToStartPosition(void);
-    PlayerControl::AcStates acStatePlayAndCapture(void);
-    PlayerControl::AcStates acStateWaitForEndAddress(void);
-    PlayerControl::AcStates acStateFinished(void);
-    PlayerControl::AcStates acStateCancelled(void);
-    PlayerControl::AcStates acStateError(void);
+    PlayerControl::AcStates acStateStart();
+    PlayerControl::AcStates acStateGetLength();
+    PlayerControl::AcStates acStateSpinDown();
+    PlayerControl::AcStates acStateSpinUpWithCapture();
+    PlayerControl::AcStates acStateMoveToStartPosition();
+    PlayerControl::AcStates acStatePlayAndCapture();
+    PlayerControl::AcStates acStateWaitForEndAddress();
+    PlayerControl::AcStates acStateFinished();
+    PlayerControl::AcStates acStateCancelled();
+    PlayerControl::AcStates acStateError();
 };
 
 #endif // PLAYERCONTROL_H

--- a/Linux-Application/DomesdayDuplicator/playerremotedialog.cpp
+++ b/Linux-Application/DomesdayDuplicator/playerremotedialog.cpp
@@ -57,7 +57,7 @@ void PlayerRemoteDialog::setEnabled(bool flag)
 }
 
 // Update the GUI
-void PlayerRemoteDialog::updateGui(void)
+void PlayerRemoteDialog::updateGui()
 {
     // Disc position unit mode
     switch(positionMode) {

--- a/Linux-Application/DomesdayDuplicator/playerremotedialog.h
+++ b/Linux-Application/DomesdayDuplicator/playerremotedialog.h
@@ -144,7 +144,7 @@ private:
     QString position;
     QString display;
 
-    void updateGui(void);
+    void updateGui();
     void positionAddValue(qint32 value);
 };
 

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -291,7 +291,7 @@ UsbCapture::~UsbCapture()
 }
 
 // Run the capture thread
-void UsbCapture::run(void)
+void UsbCapture::run()
 {
     // Set up the libusb transfers
     struct libusb_transfer **usbTransfers = nullptr;
@@ -460,7 +460,7 @@ void UsbCapture::run(void)
 
 // Allocate memory for the disk buffers
 // Note: Using vectors would be neater, but they are just too slow
-void UsbCapture::allocateDiskBuffers(void)
+void UsbCapture::allocateDiskBuffers()
 {
     qDebug() << "UsbCapture::allocateDiskBuffers(): Allocating" << (1ULL * TRANSFERSIZE * TRANSFERSPERDISKBUFFER * NUMBEROFDISKBUFFERS) / (1024 * 1024) << "MiB memory for disk buffers";
     // Allocate the disk buffers
@@ -509,7 +509,7 @@ void UsbCapture::allocateDiskBuffers(void)
 }
 
 // Free memory used for the disk buffers
-void UsbCapture::freeDiskBuffers(void)
+void UsbCapture::freeDiskBuffers()
 {
     qDebug() << "UsbCapture::freeDiskBuffers(): Freeing disk buffer memory";
     // Free up the allocated disk buffers
@@ -540,7 +540,7 @@ void UsbCapture::freeDiskBuffers(void)
 }
 
 // Thread for processing disk buffers
-void UsbCapture::runDiskBuffers(void)
+void UsbCapture::runDiskBuffers()
 {
     qDebug() << "UsbCapture::runDiskBuffers(): Thread started";
 
@@ -845,7 +845,7 @@ void UsbCapture::writeConversionBuffer(QFile *outputFile, qint32 numBytes)
 }
 
 // Start capturing
-void UsbCapture::startTransfer(void)
+void UsbCapture::startTransfer()
 {
     // Flip isOkToRename back to false; new capture
     isOkToRename = false;
@@ -856,26 +856,26 @@ void UsbCapture::startTransfer(void)
 }
 
 // Stop capturing
-void UsbCapture::stopTransfer(void)
+void UsbCapture::stopTransfer()
 {
     // Set the transfer flags to abort
     transferAbort = true;
 }
 
 // Return the current number of transfers completed
-qint32 UsbCapture::getNumberOfTransfers(void)
+qint32 UsbCapture::getNumberOfTransfers()
 {
     return statistics.transferCount;
 }
 
 // Return the current number of disk buffers written to disk
-qint32 UsbCapture::getNumberOfDiskBuffersWritten(void)
+qint32 UsbCapture::getNumberOfDiskBuffersWritten()
 {
     return numberOfDiskBuffersWritten;
 }
 
 // Return the last error text
-QString UsbCapture::getLastError(void)
+QString UsbCapture::getLastError()
 {
     return lastError;
 }

--- a/Linux-Application/DomesdayDuplicator/usbcapture.h
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.h
@@ -47,22 +47,22 @@ public:
                         bool isTestData = false);
     ~UsbCapture() override;
 
-    void startTransfer(void);
-    void stopTransfer(void);
-    qint32 getNumberOfTransfers(void);
-    qint32 getNumberOfDiskBuffersWritten(void);
-    QString getLastError(void);
+    void startTransfer();
+    void stopTransfer();
+    qint32 getNumberOfTransfers();
+    qint32 getNumberOfDiskBuffersWritten();
+    QString getLastError();
     static bool getOkToRename();
     static void getAmplitudeBuffer(const unsigned char **buffer, qint32 *numBytes);
 
 signals:
-    void transferFailed(void);
+    void transferFailed();
 
 public slots:
 
 protected slots:
     void run() override;
-    void runDiskBuffers(void);
+    void runDiskBuffers();
 
 protected:
     libusb_context *libUsbContext;
@@ -89,8 +89,8 @@ private:
     void writeBufferToDisk(QFile *outputFile, qint32 diskBufferNumber);
     void writeConversionBuffer(QFile *outputFile, qint32 numBytes);
 
-    void allocateDiskBuffers(void);
-    void freeDiskBuffers(void);
+    void allocateDiskBuffers();
+    void freeDiskBuffers();
 };
 
 #endif // USBCAPTURE_H

--- a/Linux-Application/DomesdayDuplicator/usbdevice.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbdevice.cpp
@@ -153,7 +153,7 @@ UsbDevice::~UsbDevice()
 }
 
 // Run the hot-plug detection thread
-void UsbDevice::run(void)
+void UsbDevice::run()
 {
     qint32 responseCode;
     bool currentDeviceState = false;
@@ -205,14 +205,14 @@ void UsbDevice::run(void)
     qDebug() << "UsbDevice::run(): libUSB event poll thread stopped";
 }
 
-void UsbDevice::stop(void)
+void UsbDevice::stop()
 {
     qDebug() << "UsbDevice::stop(): Stopping usbDevice thread";
     threadAbort = true;
 }
 
 // Scan for the target USB device (detects device and emits signal)
-bool UsbDevice::scanForDevice(void)
+bool UsbDevice::scanForDevice()
 {
     qDebug() << "UsbDevice::scanForDevice(): Scanning for the USB device...";
 
@@ -228,7 +228,7 @@ bool UsbDevice::scanForDevice(void)
 }
 
 // Poll for the target USB device (just detection)
-bool UsbDevice::searchForAttachedDevice(void)
+bool UsbDevice::searchForAttachedDevice()
 {
     // Attempt to find and open the USB device
     // Open the USB device
@@ -255,7 +255,7 @@ void UsbDevice::sendConfigurationCommand(bool testMode)
 }
 
 // Open the USB device
-bool UsbDevice::open(void)
+bool UsbDevice::open()
 {
     libusb_device **usbDevices;
     libusb_device *usbDevice;
@@ -307,7 +307,7 @@ bool UsbDevice::open(void)
 }
 
 // Close the USB device
-void UsbDevice::close(void)
+void UsbDevice::close()
 {
     libusb_close(usbDeviceHandle);
 }
@@ -393,7 +393,7 @@ void UsbDevice::startCapture(QString filename, bool isCaptureFormat10Bit, bool i
 }
 
 // Stop capturing from the USB device
-void UsbDevice::stopCapture(void)
+void UsbDevice::stopCapture()
 {
      // Stop the capture (closes the USB device)
     usbCapture->stopTransfer();
@@ -403,7 +403,7 @@ void UsbDevice::stopCapture(void)
 }
 
 // Transfer failed signal handler
-void UsbDevice::transferFailedSignalHandler(void)
+void UsbDevice::transferFailedSignalHandler()
 {
     // Retransmit signal to parent object
     qDebug() << "UsbDevice::transferFailedSignalHandler(): Transfer failed signal received from UsbCapture";
@@ -412,14 +412,14 @@ void UsbDevice::transferFailedSignalHandler(void)
 }
 
 // Get capture statistics
-qint32 UsbDevice::getNumberOfTransfers(void)
+qint32 UsbDevice::getNumberOfTransfers()
 {
     if (usbCapture == nullptr) return 0;
 
     return usbCapture->getNumberOfTransfers();
 }
 
-qint32 UsbDevice::getNumberOfDiskBuffersWritten(void)
+qint32 UsbDevice::getNumberOfDiskBuffersWritten()
 {
     if (usbCapture == nullptr) return 0;
 
@@ -427,7 +427,7 @@ qint32 UsbDevice::getNumberOfDiskBuffersWritten(void)
 }
 
 // Return the last recorded error message
-QString UsbDevice::getLastError(void)
+QString UsbDevice::getLastError()
 {
     return lastError;
 }

--- a/Linux-Application/DomesdayDuplicator/usbdevice.h
+++ b/Linux-Application/DomesdayDuplicator/usbdevice.h
@@ -43,21 +43,21 @@ public:
     explicit UsbDevice(QObject *parent = nullptr, quint16 vid = 0x1D50, quint16 pid = 0x603B);
     ~UsbDevice() override;
 
-    void stop(void);
+    void stop();
 
-    bool scanForDevice(void);
+    bool scanForDevice();
     void sendConfigurationCommand(bool testMode);
 
     void startCapture(QString filename, bool isCaptureFormat10Bit, bool isCaptureFormat10BitDecimated, bool isTestMode);
-    void stopCapture(void);
-    qint32 getNumberOfTransfers(void);
-    qint32 getNumberOfDiskBuffersWritten(void);
-    QString getLastError(void);
+    void stopCapture();
+    qint32 getNumberOfTransfers();
+    qint32 getNumberOfDiskBuffersWritten();
+    QString getLastError();
 
 signals:
-    void deviceAttached(void);
-    void deviceDetached(void);
-    void transferFailed(void);
+    void deviceAttached();
+    void deviceDetached();
+    void transferFailed();
 
 public slots:
 
@@ -70,7 +70,7 @@ protected:
     bool threadAbort;
 
 private slots:
-    void transferFailedSignalHandler(void);
+    void transferFailedSignalHandler();
 
 private:
     quint16 deviceVid;
@@ -79,10 +79,10 @@ private:
     UsbCapture *usbCapture;
     QString lastError;
 
-    bool open(void);
-    void close(void);
+    bool open();
+    void close();
     bool sendVendorSpecificCommand(quint8 command, quint16 value);
-    bool searchForAttachedDevice(void);
+    bool searchForAttachedDevice();
 };
 
 #endif // USBDEVICE_H

--- a/Linux-Application/dddconv/dataconversion.cpp
+++ b/Linux-Application/dddconv/dataconversion.cpp
@@ -9,7 +9,7 @@ DataConversion::DataConversion(QString inputFileNameParam, QString outputFileNam
 }
 
 // Method to process the conversion of the file
-bool DataConversion::process(void)
+bool DataConversion::process()
 {
     // Open the input file
     if (!openInputFile()) {
@@ -38,7 +38,7 @@ bool DataConversion::process(void)
 }
 
 // Method to open the input file for reading
-bool DataConversion::openInputFile(void)
+bool DataConversion::openInputFile()
 {
     // Do we have a file name for the input file?
     if (inputFileName.isEmpty()) {
@@ -67,7 +67,7 @@ bool DataConversion::openInputFile(void)
 }
 
 // Method to close the input file
-void DataConversion::closeInputFile(void)
+void DataConversion::closeInputFile()
 {
     // Is an input file open?
     if (inputFileHandle != nullptr) {
@@ -80,7 +80,7 @@ void DataConversion::closeInputFile(void)
 }
 
 // Method to open the output file for writing
-bool DataConversion::openOutputFile(void)
+bool DataConversion::openOutputFile()
 {
     // Do we have a file name for the output file?
     if (outputFileName.isEmpty()) {
@@ -109,7 +109,7 @@ bool DataConversion::openOutputFile(void)
 }
 
 // Method to close the output file
-void DataConversion::closeOutputFile(void)
+void DataConversion::closeOutputFile()
 {
     // Is an output file open?
     if (outputFileHandle != nullptr) {
@@ -122,7 +122,7 @@ void DataConversion::closeOutputFile(void)
 }
 
 // Method to pack 16-bit data into 10-bit data
-void DataConversion::packFile(void)
+void DataConversion::packFile()
 {
     qDebug() << "DataConversion::packFile(): Packing";
     QByteArray inputBuffer;
@@ -194,7 +194,7 @@ void DataConversion::packFile(void)
 }
 
 // Method to unpack 10-bit data into 16-bit data
-void DataConversion::unpackFile(void)
+void DataConversion::unpackFile()
 {
     qDebug() << "DataConversion::unpackFile(): Unpacking";
     QByteArray inputBuffer;

--- a/Linux-Application/dddconv/dataconversion.h
+++ b/Linux-Application/dddconv/dataconversion.h
@@ -11,7 +11,7 @@ class DataConversion : public QObject
 public:
     explicit DataConversion(QString inputFileNameParam, QString outputFileNameParam, bool isPackingParam, QObject *parent = nullptr);
 
-    bool process(void);
+    bool process();
 signals:
 
 public slots:
@@ -25,12 +25,12 @@ private:
     QFile *outputFileHandle;
 
     // Private methods
-    bool openInputFile(void);
-    void closeInputFile(void);
-    bool openOutputFile(void);
-    void closeOutputFile(void);
-    void packFile(void);
-    void unpackFile(void);
+    bool openInputFile();
+    void closeInputFile();
+    bool openOutputFile();
+    void closeOutputFile();
+    void packFile();
+    void unpackFile();
 };
 
 #endif // DATACONVERSION_H

--- a/Linux-Application/dddutil/analysetestdata.cpp
+++ b/Linux-Application/dddutil/analysetestdata.cpp
@@ -145,7 +145,7 @@ void AnalyseTestData::quit()
 // File conversion methods --------------------------------------------------------------------------------------------
 
 // Open the files and get ready to convert
-bool AnalyseTestData::analyseSampleStart(void)
+bool AnalyseTestData::analyseSampleStart()
 {
     if (isInputTenBitTs) qDebug() << "AnalyseTestData::analyseSampleStart(): Reading in 10-bit format";
     else qDebug() << "AnalyseTestData::analyseSampleStart(): Reading in 16-bit format";
@@ -200,7 +200,7 @@ bool AnalyseTestData::analyseSampleStart(void)
 }
 
 // Process a buffer of sample data
-bool AnalyseTestData::analyseSampleProcess(void)
+bool AnalyseTestData::analyseSampleProcess()
 {
     // Define a sample buffer for the transfer of data
     QVector<quint16> sampleBuffer;
@@ -242,7 +242,7 @@ bool AnalyseTestData::analyseSampleProcess(void)
 }
 
 // Close the sample files and clean up
-void AnalyseTestData::analyseSampleStop(void)
+void AnalyseTestData::analyseSampleStop()
 {
     // Destroy the input sample object
     inputSample->deleteLater();

--- a/Linux-Application/dddutil/analysetestdata.h
+++ b/Linux-Application/dddutil/analysetestdata.h
@@ -56,8 +56,8 @@ public:
 
 signals:
     void percentageProcessed(qint32);
-    void completed(void);
-    void testFailed(void);
+    void completed();
+    void testFailed();
 
 protected:
     void run() override;
@@ -93,9 +93,9 @@ private:
     bool firstTest;
     bool testSuccessful;
 
-    bool analyseSampleStart(void);
-    bool analyseSampleProcess(void);
-    void analyseSampleStop(void);
+    bool analyseSampleStart();
+    bool analyseSampleProcess();
+    void analyseSampleStop();
 
     bool analyseDataIntegrity(QVector<quint16> sample);
 };

--- a/Linux-Application/dddutil/fileconverter.cpp
+++ b/Linux-Application/dddutil/fileconverter.cpp
@@ -148,7 +148,7 @@ void FileConverter::quit()
 // File conversion methods --------------------------------------------------------------------------------------------
 
 // Open the files and get ready to convert
-bool FileConverter::convertSampleStart(void)
+bool FileConverter::convertSampleStart()
 {
     qDebug() << "FileConverter::convertSampleStart(): Saving output file as " << outputFilenameTs;
 
@@ -209,7 +209,7 @@ bool FileConverter::convertSampleStart(void)
 }
 
 // Process a buffer of sample data
-bool FileConverter::convertSampleProcess(void)
+bool FileConverter::convertSampleProcess()
 {
     // Define a sample buffer for the transfer of data
     QVector<quint16> sampleBuffer;
@@ -244,7 +244,7 @@ bool FileConverter::convertSampleProcess(void)
 }
 
 // Close the sample files and clean up
-void FileConverter::convertSampleStop(void)
+void FileConverter::convertSampleStop()
 {
     // Destroy the input sample object
     inputSample->deleteLater();
@@ -269,7 +269,7 @@ bool FileConverter::openOutputSample(QString filename)
 }
 
 // Close the output RF sample
-void FileConverter::closeOutputSample(void)
+void FileConverter::closeOutputSample()
 {
     // Is a sample file open?
     if (outputSampleFileHandleTs != nullptr) {

--- a/Linux-Application/dddutil/fileconverter.h
+++ b/Linux-Application/dddutil/fileconverter.h
@@ -56,7 +56,7 @@ public:
 
 signals:
     void percentageProcessed(qint32);
-    void completed(void);
+    void completed();
 
 protected:
     void run() override;
@@ -92,13 +92,13 @@ private:
     qint64 endSampleTs;
     qint64 samplesToConvertTs;
 
-    bool convertSampleStart(void);
-    bool convertSampleProcess(void);
-    void convertSampleStop(void);
+    bool convertSampleStart();
+    bool convertSampleProcess();
+    void convertSampleStop();
 
     bool writeOutputSample(QVector<quint16> sampleBuffer, bool isTenBit);
     bool openOutputSample(QString filename);
-    void closeOutputSample(void);
+    void closeOutputSample();
     qint64 samplesToTenBitBytes(qint64 numberOfSamples);
 };
 

--- a/Linux-Application/dddutil/inputsample.cpp
+++ b/Linux-Application/dddutil/inputsample.cpp
@@ -73,7 +73,7 @@ bool InputSample::open(QString filename)
 }
 
 // Close the input sample
-void InputSample::close(void)
+void InputSample::close()
 {
     // Is a sample file open?
     if (sampleFileHandle != nullptr) {
@@ -236,13 +236,13 @@ void InputSample::seek(qint64 numberOfSamples)
 // Get and set methods ------------------------------------------------------------------------------------------------
 
 // Determine if input sample is valid
-bool InputSample::isInputSampleValid(void)
+bool InputSample::isInputSampleValid()
 {
     return sampleIsValid;
 }
 
 // Get the number of samples in the input sample
-qint64 InputSample::getNumberOfSamples(void)
+qint64 InputSample::getNumberOfSamples()
 {
     return numberOfSamples;
 }

--- a/Linux-Application/dddutil/inputsample.h
+++ b/Linux-Application/dddutil/inputsample.h
@@ -44,8 +44,8 @@ public:
     QVector<quint16> read(qint32 maximumSamples);
     void seek(qint64 numberOfSamples);
 
-    bool isInputSampleValid(void);
-    qint64 getNumberOfSamples(void);
+    bool isInputSampleValid();
+    qint64 getNumberOfSamples();
 
 signals:
 
@@ -59,7 +59,7 @@ private:
     bool sampleIsValid;
 
     bool open(QString filename);
-    void close(void);
+    void close();
 
     qint64 samplesToTenBitBytes(qint64 numberOfSamples);
     qint64 tenBitBytesToSamples(qint64 numberOfBytes);

--- a/Linux-Application/dddutil/mainwindow.cpp
+++ b/Linux-Application/dddutil/mainwindow.cpp
@@ -76,7 +76,7 @@ MainWindow::~MainWindow()
 // GUI Update functions -----------------------------------------------------------------------------------------------
 
 // Actions on file not loaded
-void MainWindow::noInputFileSpecified(void)
+void MainWindow::noInputFileSpecified()
 {
     // Menu options
     ui->actionOpen_10_bit_File->setEnabled(true);
@@ -98,7 +98,7 @@ void MainWindow::noInputFileSpecified(void)
 }
 
 // Actions on file loaded
-void MainWindow::inputFileSpecified(void)
+void MainWindow::inputFileSpecified()
 {
     // Menu options
     ui->actionOpen_10_bit_File->setEnabled(true);
@@ -335,14 +335,14 @@ void MainWindow::conversionPercentageProcessedSignalHandler(qint32 percentage)
 }
 
 // Handle the conversion completed signal sent by the file converter thread
-void MainWindow::conversionCompletedSignalHandler(void)
+void MainWindow::conversionCompletedSignalHandler()
 {
     // Hide the process dialogue (re-enables main window)
     conversionProgressDialog->hide();
 }
 
 // Handle the progress dialogue cancelled signal sent by the progress dialogue
-void MainWindow::conversionCancelledSignalHandler(void)
+void MainWindow::conversionCancelledSignalHandler()
 {
     // Cancel the conversion in progress
     fileConverter.cancelConversion();
@@ -358,7 +358,7 @@ void MainWindow::analyseTestDataPercentageProcessedSignalHandler(qint32 percenta
 }
 
 // Handle the conversion completed signal sent by the test data analyser thread
-void MainWindow::analyseTestDataCompletedSignalHandler(void)
+void MainWindow::analyseTestDataCompletedSignalHandler()
 {
     // Hide the process dialogue (re-enables main window)
     analyseTestDataProgressDialog->hide();
@@ -370,14 +370,14 @@ void MainWindow::analyseTestDataCompletedSignalHandler(void)
 }
 
 // Handle the progress dialogue cancelled signal sent by the progress dialogue
-void MainWindow::analyseTestDataCancelledSignalHandler(void)
+void MainWindow::analyseTestDataCancelledSignalHandler()
 {
     // Cancel the analysis in progress
     analyseTestData.cancelAnalysis();
 }
 
 // Handle the test failed signal from the test data analyser
-void MainWindow::analyseTestDataTestFailedSignalHandler(void)
+void MainWindow::analyseTestDataTestFailedSignalHandler()
 {
     // Hide the process dialogue (re-enables main window)
     analyseTestDataProgressDialog->hide();

--- a/Linux-Application/dddutil/mainwindow.h
+++ b/Linux-Application/dddutil/mainwindow.h
@@ -64,19 +64,19 @@ private slots:
     void on_endTimeEdit_userTimeChanged(const QTime &endTime);
 
     void conversionPercentageProcessedSignalHandler(qint32 percentage);
-    void conversionCompletedSignalHandler(void);
-    void conversionCancelledSignalHandler(void);
+    void conversionCompletedSignalHandler();
+    void conversionCancelledSignalHandler();
 
     void analyseTestDataPercentageProcessedSignalHandler(qint32 percentage);
-    void analyseTestDataCompletedSignalHandler(void);
-    void analyseTestDataCancelledSignalHandler(void);
-    void analyseTestDataTestFailedSignalHandler(void);
+    void analyseTestDataCompletedSignalHandler();
+    void analyseTestDataCancelledSignalHandler();
+    void analyseTestDataTestFailedSignalHandler();
 
 private:
     Ui::MainWindow *ui;
 
-    void noInputFileSpecified(void);
-    void inputFileSpecified(void);
+    void noInputFileSpecified();
+    void inputFileSpecified();
 
     QString inputFilename;
     QString outputFilename;

--- a/Linux-Application/dddutil/progressdialog.h
+++ b/Linux-Application/dddutil/progressdialog.h
@@ -51,7 +51,7 @@ public:
     void setText(QString message);
 
 signals:
-    void cancelled(void);
+    void cancelled();
 
 private:
     Ui::ProgressDialog *ui;

--- a/Linux-Application/dddutil/sampledetails.cpp
+++ b/Linux-Application/dddutil/sampledetails.cpp
@@ -27,7 +27,7 @@
 
 #include "sampledetails.h"
 
-SampleDetails::SampleDetails(void)
+SampleDetails::SampleDetails()
 {
     // Set default object values
     sizeOnDisc = 0;
@@ -72,7 +72,7 @@ bool SampleDetails::getInputSampleDetails(QString inputFilename, bool isTenBit)
 
 // Get the size of the sample file on disc and return as a
 // readable string
-QString SampleDetails::getSizeOnDisc(void)
+QString SampleDetails::getSizeOnDisc()
 {
     QString sizeText;
 
@@ -88,21 +88,21 @@ QString SampleDetails::getSizeOnDisc(void)
 }
 
 // Get the number of samples contained in the sample file
-qint64 SampleDetails::getNumberOfSamples(void)
+qint64 SampleDetails::getNumberOfSamples()
 {
     return numberOfSamples;
 }
 
 // Get the approximate duration of the sample file and
 // return it as the number of seconds
-qint32 SampleDetails::getDurationSeconds(void)
+qint32 SampleDetails::getDurationSeconds()
 {
     return static_cast<qint32>(numberOfSamples / 40000000);
 }
 
 // Get the approximate duration of the sample file and
 // return it as a time string "hh:mm:ss"
-QString SampleDetails::getDurationString(void)
+QString SampleDetails::getDurationString()
 {
     // Number of samples / 40 MSPS sampling rate
     qint64 duration = numberOfSamples / 40000000;
@@ -113,7 +113,7 @@ QString SampleDetails::getDurationString(void)
 
 // Get the input file format, returns true if 10-bit
 // and false if 16-bit
-bool SampleDetails::getInputFileFormat(void)
+bool SampleDetails::getInputFileFormat()
 {
     return isInputFileTenBit;
 }

--- a/Linux-Application/dddutil/sampledetails.h
+++ b/Linux-Application/dddutil/sampledetails.h
@@ -37,14 +37,14 @@ class SampleDetails
 {
 
 public:
-    SampleDetails(void);
+    SampleDetails();
     bool getInputSampleDetails(QString inputFilename, bool isTenBit);
 
-    QString getSizeOnDisc(void);
-    qint64 getNumberOfSamples(void);
-    qint32 getDurationSeconds(void);
-    QString getDurationString(void);
-    bool getInputFileFormat(void);
+    QString getSizeOnDisc();
+    qint64 getNumberOfSamples();
+    qint32 getDurationSeconds();
+    QString getDurationString();
+    bool getInputFileFormat();
 
 signals:
 


### PR DESCRIPTION
CC @Gamnn, who'd also spotted this.

Rework the per-side notes and mint mark logic, since it wasn't producing sensible filenames in some cases.

Add UI settings to enable each of these to be enabled/disabled individually, since not everybody will want this behaviour at all, and it can be useful to enable only one (e.g. if you use notes to log the player used).

As this adds new settings to the UI tab, simplify the amplitude display settings and make them match the style of the rest of the UI.

Remove C-style `(void)` arguments throughout the DDD code.