### PR TITLE
Added MacOS support

### DIFF
--- a/Linux-Application/DomesdayDuplicator/CMakeLists.txt
+++ b/Linux-Application/DomesdayDuplicator/CMakeLists.txt
@@ -49,4 +49,7 @@ if(WIN32)
     )
 endif()
 
-install(TARGETS DomesdayDuplicator)
+install(TARGETS DomesdayDuplicator
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION bin
+)

--- a/Linux-Application/DomesdayDuplicator/usbcapture.cpp
+++ b/Linux-Application/DomesdayDuplicator/usbcapture.cpp
@@ -35,6 +35,9 @@
 #else
     #include <sys/mman.h>
 #endif
+#ifdef __APPLE__
+    #include <iostream>
+#endif
 
 // Notes on transfer and disk buffering:
 //
@@ -330,13 +333,22 @@ void UsbCapture::run()
     // Save the current scheduling policy and parameters
 #ifdef _WIN32
     // TODO: Implement pthread-win32 for scheduling on Windows
-#else
+#endif
+
+#ifdef _LINUX
     int oldSchedPolicy = sched_getscheduler(0);
     if (oldSchedPolicy == -1) oldSchedPolicy = SCHED_OTHER;
     struct sched_param oldSchedParam;
     if (sched_getparam(0, &oldSchedParam) == -1) oldSchedParam.sched_priority = 0;
 #endif
 
+#ifdef __APPLE__
+    int policy;
+    struct sched_param oldSchedParam;
+    pthread_getschedparam(pthread_self(), &policy, &oldSchedParam);
+#endif
+
+#ifdef _LINUX
     // Enable real-time scheduling for this thread
     int minSchedPriority = sched_get_priority_min(SCHED_RR);
     int maxSchedPriority = sched_get_priority_max(SCHED_RR);
@@ -353,6 +365,24 @@ void UsbCapture::run()
         // Continue anyway, but print a warning
         qInfo() << "UsbCapture::run(): Unable to enable real-time scheduling for capture thread";
     }
+#endif
+
+#ifdef __APPLE__
+    int minSchedPriority = sched_get_priority_min(SCHED_OTHER);
+    int maxSchedPriority = sched_get_priority_max(SCHED_OTHER);
+    struct sched_param schedParams;
+    if (minSchedPriority == -1 || maxSchedPriority == -1) {
+    	schedParams.sched_priority = 0;
+    } else {
+    	schedParams.sched_priority = (minSchedPriority + (3 * maxSchedPriority)) / 4;
+    }
+
+    if (pthread_setschedparam(pthread_self(), SCHED_OTHER, &schedParams) == 0) {	
+	std::cout << "UsbCapture::run(): Thread priority set with policy SCHED_OTHER" << std::endl;    
+    } else {
+    	std::cout << "UsbCapture::run(): Unable to set thread priority" << std::endl;
+    }
+#endif
 
     // Set up the initial transfers
     for (qint32 transferNumber = 0; transferNumber < SIMULTANEOUSTRANSFERS; transferNumber++) {
@@ -419,10 +449,18 @@ void UsbCapture::run()
 
 #ifdef _WIN32
     // TODO: Implement pthread-win32 for scheduling on Windows
-#else
+#endif
+
+#ifdef _LINUX
     // Return to the original scheduling policy while we're cleaning up
     if (sched_setscheduler(0, oldSchedPolicy, &oldSchedParam) == -1) {
         qDebug() << "UsbCapture::run(): Unable to restore original scheduling policy";
+    }
+#endif
+
+#ifdef __APPLE__
+    if (pthread_setschedparam(pthread_self(), policy, &schedParams) != 0) {
+    	std::cout << "UsbCapture::run(): Unable to restore original scheduling policy" << std::endl;
     }
 #endif
 

--- a/Linux-Application/dddutil/CMakeLists.txt
+++ b/Linux-Application/dddutil/CMakeLists.txt
@@ -19,4 +19,7 @@ target_link_libraries(dddutil PRIVATE
     Qt::Widgets
 )
 
-install(TARGETS dddutil)
+install(TARGETS dddutil
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION bin
+)


### PR DESCRIPTION
Minimum changes to allow Domesday to compile and run under MacOS.

Linux-Application % cmake .
-- The C compiler identification is AppleClang 14.0.0.14000029 -- The CXX compiler identification is AppleClang 14.0.0.14000029 -- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped -- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped -- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success -- Found Threads: TRUE
-- Found OpenGL: /Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks/OpenGL.framework -- Found WrapOpenGL: TRUE
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) -- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found PkgConfig: /usr/local/bin/pkg-config (found version "0.29.2") -- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.26
-- Configuring done (2.9s)
-- Generating done (0.2s)
-- Build files have been written to: /Users/user/Documents/GitHub/DomesdayDuplicator/Linux-Application
user@MacBook-Pro Linux-Application % cmake
user@MacBook-Pro Linux-Application % make
[  0%] Built target dddutil_autogen_timestamp_deps
[  0%] Built target dddconv_autogen_timestamp_deps
[  0%] Built target DomesdayDuplicator_autogen_timestamp_deps
[  2%] Automatic MOC and UIC for target DomesdayDuplicator
[  5%] Automatic MOC and UIC for target dddutil
[  7%] Automatic MOC and UIC for target dddconv
[  7%] Built target dddconv_autogen
[ 10%] Building CXX object dddconv/CMakeFiles/dddconv.dir/dddconv_autogen/mocs_compilation.cpp.o
[ 13%] Building CXX object dddconv/CMakeFiles/dddconv.dir/main.cpp.o
[ 15%] Building CXX object dddconv/CMakeFiles/dddconv.dir/dataconversion.cpp.o
[ 15%] Built target dddutil_autogen
[ 18%] Building CXX object dddutil/CMakeFiles/dddutil.dir/dddutil_autogen/mocs_compilation.cpp.o
[ 23%] Building CXX object dddutil/CMakeFiles/dddutil.dir/fileconverter.cpp.o
[ 23%] Building CXX object dddutil/CMakeFiles/dddutil.dir/about.cpp.o
[ 26%] Building CXX object dddutil/CMakeFiles/dddutil.dir/analysetestdata.cpp.o
[ 28%] Building CXX object dddutil/CMakeFiles/dddutil.dir/inputsample.cpp.o
[ 31%] Building CXX object dddutil/CMakeFiles/dddutil.dir/main.cpp.o
[ 34%] Linking CXX executable dddconv
[ 36%] Built target dddconv
[ 39%] Building CXX object dddutil/CMakeFiles/dddutil.dir/mainwindow.cpp.o
[ 42%] Building CXX object dddutil/CMakeFiles/dddutil.dir/progressdialog.cpp.o
[ 44%] Building CXX object dddutil/CMakeFiles/dddutil.dir/sampledetails.cpp.o
[ 44%] Built target DomesdayDuplicator_autogen
[ 47%] Generating qrc_resources.cpp
[ 50%] Linking CXX executable dddutil.app/Contents/MacOS/dddutil
[ 52%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/DomesdayDuplicator_autogen/mocs_compilation.cpp.o
[ 55%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/advancednamingdialog.cpp.o
[ 57%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/amplitudemeasurement.cpp.o
[ 63%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/aboutdialog.cpp.o
[ 65%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/configuration.cpp.o
[ 65%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/automaticcapturedialog.cpp.o
[ 68%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/configurationdialog.cpp.o
[ 71%] Built target dddutil
[ 73%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/main.cpp.o
[ 76%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/mainwindow.cpp.o
[ 78%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/playercommunication.cpp.o
[ 81%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/playercontrol.cpp.o
[ 84%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/playerremotedialog.cpp.o
[ 86%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/qcustomplot.cpp.o
[ 89%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/usbcapture.cpp.o
[ 92%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/usbdevice.cpp.o
[ 94%] Building CXX object DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/qrc_resources.cpp.o
/Users/user/Documents/GitHub/DomesdayDuplicator/Linux-Application/DomesdayDuplicator/qcustomplot.cpp:15299:1: warning: '/*' within block comment [-Wcomment]
/*!
^
1 warning generated.
[ 97%] Linking CXX executable DomesdayDuplicator.app/Contents/MacOS/DomesdayDuplicator
[100%] Built target DomesdayDuplicator