### PR TITLE
Update UsbDeviceBase.cpp to fix macOS builds

### DIFF
--- a/Linux-Application/DomesdayDuplicator/UsbDeviceBase.cpp
+++ b/Linux-Application/DomesdayDuplicator/UsbDeviceBase.cpp
@@ -507,7 +507,7 @@ bool UsbDeviceBase::UsbTransferStopRequested() const
 //----------------------------------------------------------------------------------------------------------------------
 UsbDeviceBase::DiskBufferEntry& UsbDeviceBase::GetDiskBuffer(size_t bufferNo)
 {
-    assert(bufferNo < bufferCount);
+    assert(bufferNo < totalDiskBufferEntryCount);
     return diskBufferEntries[bufferNo];
 }
 


### PR DESCRIPTION
The DdD app fails to build on macOS Sonoma 14.6 (23G80) with the following error:

```
DomesdayDuplicator/Linux-Application/DomesdayDuplicator/UsbDeviceBase.cpp:510:23: error: use of undeclared identifier 'bufferCount'
  510 |     assert(bufferNo < bufferCount);
      |                       ^
1 error generated.
make[2]: *** [DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/UsbDeviceBase.cpp.o] Error 1
make[1]: *** [DomesdayDuplicator/CMakeFiles/DomesdayDuplicator.dir/all] Error 2
make: *** [all] Error 2
```

I gave it a quick once over and assumed it meant to assert `totalDiskBufferEntryCount `. This is more of an fyi than a proper fix though, but it works enough to build and run.