### PR TITLE
Two minor fixes for DomesdayDuplicator

### DIFF
--- a/Linux-Application/DomesdayDuplicator/ILogger.inl
+++ b/Linux-Application/DomesdayDuplicator/ILogger.inl
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <sstream>

--- a/Linux-Application/DomesdayDuplicator/mainwindow.cpp
+++ b/Linux-Application/DomesdayDuplicator/mainwindow.cpp
@@ -577,7 +577,7 @@ void MainWindow::updateCaptureStatus()
         // Populate the player serial info
         infoFile["serialInfo"]["playerModelCode"] = playerControl->getPlayerModelCode().toStdString();
         infoFile["serialInfo"]["playerModelName"] = playerControl->getPlayerModelName().toStdString();
-        infoFile["serialInfo"]["playerVesionNumber"] = playerControl->getPlayerVersionNumber().toStdString();
+        infoFile["serialInfo"]["playerVersionNumber"] = playerControl->getPlayerVersionNumber().toStdString();
         auto discType = playerDiscTypeCached;
         if (discType == PlayerCommunication::DiscType::CAV)
         {


### PR DESCRIPTION
Add a missing `#include`, and fix a typo in the JSON structure.

(It would be worth running include-what-you-use across the code at some point - it has a lot of reliance on transitive includes that is likely to cause problems in the future...)