### PR TITLE
20260820 002

### DIFF
--- a/ddd-gui/CMakeLists.txt
+++ b/ddd-gui/CMakeLists.txt
@@ -207,7 +207,12 @@ endif()
 # module rather than part of qtbase, so a distribution build needs its package installed.
 # The capture application this one replaced required it too, so no machine that could
 # build this repository is losing anything.
-find_package(Qt6 6.5 REQUIRED COMPONENTS Core Gui Widgets SerialPort Test)
+#
+# Network is for QLocalServer and QLocalSocket, and for nothing else: the control socket a
+# script stops a capture through. Despite the module's name nothing here opens a network
+# socket — a local socket is a named pipe on Windows and a Unix domain socket everywhere
+# else, both of which are reachable only from the machine the application is running on.
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Gui Widgets Network SerialPort Test)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/ddd-gui/src/gui/CMakeLists.txt
+++ b/ddd-gui/src/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(ddd_gui_lib STATIC
     bringup_text.cpp
     bringup_worker.cpp
     bundled_update.cpp
+    capture_cli.cpp
     capture_controller.cpp
     capture_naming_dialog.cpp
     capture_naming_form.cpp
@@ -50,6 +51,7 @@ add_library(ddd_gui_lib STATIC
     qt_serial_port.cpp
     serial_port_scanner.cpp
     settings_dialog.cpp
+    signal_watcher.cpp
     spectrum_panel.cpp
     statistics_panel.cpp
     statistics_presenter.cpp

--- a/ddd-gui/src/gui/CMakeLists.txt
+++ b/ddd-gui/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(ddd_gui_lib STATIC
     bringup_worker.cpp
     bundled_update.cpp
     capture_cli.cpp
+    capture_control_server.cpp
     capture_controller.cpp
     capture_naming_dialog.cpp
     capture_naming_form.cpp
@@ -31,6 +32,7 @@ add_library(ddd_gui_lib STATIC
     capture_plan_form.cpp
     capture_failure_presenter.cpp
     capture_settings.cpp
+    capture_stop_client.cpp
     console_attach.cpp
     examine_dialog.cpp
     firmware_dialog.cpp
@@ -87,6 +89,7 @@ target_link_libraries(ddd_gui_lib
         ddd_player
         Qt6::Core
         Qt6::Gui
+        Qt6::Network
         Qt6::Widgets
         Qt6::SerialPort
 )

--- a/ddd-gui/src/gui/CMakeLists.txt
+++ b/ddd-gui/src/gui/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(ddd_gui_lib STATIC
     firmware_text.cpp
     floating_dock_drag.cpp
     gain_choices.cpp
+    headless_capture_runner.cpp
     log_message_model.cpp
     log_panel.cpp
     main_window.cpp

--- a/ddd-gui/src/gui/capture_cli.cpp
+++ b/ddd-gui/src/gui/capture_cli.cpp
@@ -1,0 +1,308 @@
+/************************************************************************
+
+    capture_cli.cpp
+
+    The capture options the command line accepts, and what they mean
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include "capture_cli.h"
+
+#include <QCommandLineParser>
+#include <QFileInfo>
+#include <QLatin1String>
+#include <QStringList>
+
+namespace ddd::gui {
+namespace {
+
+// The switch names, in one place: the parser is given them here, and
+// WantsCoreApplication() below has to recognise two of them without a parser.
+constexpr const char* kStartCaptureName = "start-capture";
+constexpr const char* kStopCaptureName = "stop-capture";
+constexpr const char* kHeadlessName = "headless";
+constexpr const char* kCaptureDirectoryName = "capture-directory";
+constexpr const char* kCaptureNameName = "capture-name";
+constexpr const char* kSampleRateName = "sample-rate";
+constexpr const char* kDurationLimitName = "duration-limit";
+constexpr const char* kOutputFormatName = "output-format";
+
+// The format words, spelled as the settings file spells them, so that a script
+// and a settings file name the same format the same way. The reading of them
+// here is strict where the settings loader's is forgiving: a settings file
+// naming a format this build does not have should still produce a working
+// capture, but a command line naming one is a typo, and a script that silently
+// wrote FLAC when it asked for raw samples would be found out much later.
+constexpr const char* kFlacFormatWord = "flac";
+constexpr const char* kSigned16BitFormatWord = "s16";
+
+// The rates this build can capture at, derived from the decimation factors
+// rather than written out beside them: a factor added to capture_format.h
+// appears on the command line without anything having to be kept in step.
+constexpr int kSupportedDecimationFactors[] = {capture::kUndecimatedFactor,
+                                               capture::kTapeDecimationFactor};
+
+constexpr uint32_t kHzPerMsps = 1'000'000;
+
+int MegasamplesPerSecondFor(int decimation_factor) {
+  return static_cast<int>(capture::SampleRateHzFor(decimation_factor) /
+                          kHzPerMsps);
+}
+
+std::optional<int> DecimationFactorForRate(int megasamples_per_second) {
+  for (const int factor : kSupportedDecimationFactors) {
+    if (MegasamplesPerSecondFor(factor) == megasamples_per_second) {
+      return factor;
+    }
+  }
+  return std::nullopt;
+}
+
+QString SupportedRateWords() {
+  QStringList rates;
+  for (const int factor : kSupportedDecimationFactors) {
+    rates.append(QString::number(MegasamplesPerSecondFor(factor)));
+  }
+  return rates.join(QStringLiteral(" or "));
+}
+
+// Whether a raw argument is this option, in either of the spellings Qt's parser
+// accepts for a long name.
+bool IsOptionToken(const QString& token, const char* name) {
+  const QString long_form = QLatin1String("--") + QLatin1String(name);
+  const QString short_form = QLatin1String("-") + QLatin1String(name);
+  return token == long_form || token == short_form;
+}
+
+}  // namespace
+
+bool CaptureCliOptions::HasAttributeOverrides() const {
+  return capture_directory.has_value() || capture_name.has_value() ||
+         decimation_factor.has_value() || duration_limit_seconds.has_value() ||
+         output_format.has_value();
+}
+
+CaptureCliOptionSet AddCaptureCliOptions(QCommandLineParser& parser) {
+  CaptureCliOptionSet set{
+      QCommandLineOption(
+          QLatin1String(kStartCaptureName),
+          QStringLiteral("Start capturing as soon as a device is found. The "
+                         "window still opens unless --headless is given.")),
+      QCommandLineOption(
+          QLatin1String(kStopCaptureName),
+          QStringLiteral("Stop the capture a running instance is taking, wait "
+                         "for its file to be finished, and exit.")),
+      QCommandLineOption(
+          QLatin1String(kHeadlessName),
+          QStringLiteral("Run with no window. Requires --start-capture, and "
+                         "runs until the duration limit, --stop-capture, or an "
+                         "interrupt.")),
+      QCommandLineOption(
+          QLatin1String(kCaptureDirectoryName),
+          QStringLiteral("Write the capture here instead of the configured "
+                         "folder. Created if it does not exist."),
+          QStringLiteral("directory")),
+      QCommandLineOption(
+          QLatin1String(kCaptureNameName),
+          QStringLiteral("Name the capture this, without a suffix, instead of "
+                         "the configured or generated name."),
+          QStringLiteral("name")),
+      QCommandLineOption(
+          QLatin1String(kSampleRateName),
+          QStringLiteral("Capture at this rate in Msps: %1. Decimation is done "
+                         "by the device.")
+              .arg(SupportedRateWords()),
+          QStringLiteral("msps")),
+      QCommandLineOption(
+          QLatin1String(kDurationLimitName),
+          QStringLiteral("Stop automatically after this many seconds. Omit it "
+                         "to run until stopped."),
+          QStringLiteral("seconds")),
+      QCommandLineOption(QLatin1String(kOutputFormatName),
+                         QStringLiteral("Write the capture as %1 or %2.")
+                             .arg(QLatin1String(kFlacFormatWord),
+                                  QLatin1String(kSigned16BitFormatWord)),
+                         QStringLiteral("format")),
+  };
+
+  parser.addOption(set.start_capture);
+  parser.addOption(set.stop_capture);
+  parser.addOption(set.headless);
+  parser.addOption(set.capture_directory);
+  parser.addOption(set.capture_name);
+  parser.addOption(set.sample_rate);
+  parser.addOption(set.duration_limit);
+  parser.addOption(set.output_format);
+
+  return set;
+}
+
+CaptureCliParseResult ParseCaptureCliOptions(const QCommandLineParser& parser,
+                                             const CaptureCliOptionSet& set) {
+  CaptureCliParseResult result;
+  CaptureCliOptions& options = result.options;
+
+  options.start_capture = parser.isSet(set.start_capture);
+  options.stop_capture = parser.isSet(set.stop_capture);
+  options.headless = parser.isSet(set.headless);
+
+  if (parser.isSet(set.capture_directory)) {
+    const QString directory = parser.value(set.capture_directory).trimmed();
+    if (directory.isEmpty()) {
+      result.error = QStringLiteral(
+          "--capture-directory needs a folder. Leave it out to use the "
+          "configured one.");
+      return result;
+    }
+
+    // Existing and not a folder is the only case worth refusing. A folder that
+    // is not there yet is made when the capture is opened, exactly as it is for
+    // a capture started from the window, so a script that names a folder per
+    // disc works without creating it first.
+    const QFileInfo info(directory);
+    if (info.exists() && !info.isDir()) {
+      result.error = QStringLiteral("--capture-directory '%1' is not a folder.")
+                         .arg(directory);
+      return result;
+    }
+    options.capture_directory = directory;
+  }
+
+  if (parser.isSet(set.capture_name)) {
+    const QString name = parser.value(set.capture_name).trimmed();
+    if (name.isEmpty()) {
+      result.error = QStringLiteral(
+          "--capture-name needs a name. Leave it out for the generated one.");
+      return result;
+    }
+
+    // A name, not a path. The window's name field would accept a separator and
+    // fail much later when the file was opened; a script gets told now, which
+    // is the whole point of checking a command line rather than a text box.
+    if (name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\'))) {
+      result.error =
+          QStringLiteral(
+              "--capture-name '%1' contains a path separator. Name the folder "
+              "with --capture-directory.")
+              .arg(name);
+      return result;
+    }
+    options.capture_name = name;
+  }
+
+  if (parser.isSet(set.sample_rate)) {
+    const QString text = parser.value(set.sample_rate).trimmed();
+    bool numeric = false;
+    const int rate = text.toInt(&numeric);
+    const std::optional<int> factor =
+        numeric ? DecimationFactorForRate(rate) : std::nullopt;
+    if (!factor.has_value()) {
+      result.error =
+          QStringLiteral("Unknown --sample-rate '%1'. Use %2, in Msps.")
+              .arg(text, SupportedRateWords());
+      return result;
+    }
+    options.decimation_factor = factor;
+  }
+
+  if (parser.isSet(set.duration_limit)) {
+    const QString text = parser.value(set.duration_limit).trimmed();
+    bool numeric = false;
+    const int seconds = text.toInt(&numeric);
+
+    // Zero means "no limit" in the settings, and is refused here rather than
+    // accepted as one: a script that computed a limit of zero has a bug, and
+    // silently capturing until something else stopped it would hide it.
+    if (!numeric || seconds < 1 ||
+        seconds > CaptureSettings::kMaximumDurationLimitSeconds) {
+      result.error =
+          QStringLiteral(
+              "Unknown --duration-limit '%1'. Use 1 to %2 seconds (%3 hours), "
+              "or leave it out to capture until stopped.")
+              .arg(text)
+              .arg(CaptureSettings::kMaximumDurationLimitSeconds)
+              .arg(CaptureSettings::kMaximumDurationLimitMinutes / 60);
+      return result;
+    }
+    options.duration_limit_seconds = seconds;
+  }
+
+  if (parser.isSet(set.output_format)) {
+    const QString word = parser.value(set.output_format).trimmed().toLower();
+    if (word == QLatin1String(kFlacFormatWord)) {
+      options.output_format = capture::CaptureOutputFormat::kFlac;
+    } else if (word == QLatin1String(kSigned16BitFormatWord)) {
+      options.output_format = capture::CaptureOutputFormat::kSigned16Bit;
+    } else {
+      result.error =
+          QStringLiteral("Unknown --output-format '%1'. Use %2 or %3.")
+              .arg(parser.value(set.output_format),
+                   QLatin1String(kFlacFormatWord),
+                   QLatin1String(kSigned16BitFormatWord));
+      return result;
+    }
+  }
+
+  // --stop-capture is a message to a process that is already running and has
+  // already been told what to capture. Anything else on the line is an
+  // instruction with nowhere to go, so it is refused rather than dropped.
+  if (options.stop_capture && (options.start_capture || options.headless ||
+                               options.HasAttributeOverrides())) {
+    result.error = QStringLiteral(
+        "--stop-capture stops a capture that is already running, so it cannot "
+        "be given with the options that set one up.");
+    return result;
+  }
+
+  if (options.headless && !options.start_capture) {
+    result.error = QStringLiteral(
+        "--headless needs --start-capture. Without a window and without a "
+        "capture there would be nothing for the application to do.");
+    return result;
+  }
+
+  return result;
+}
+
+void ApplyCliOverrides(CaptureSettings& settings,
+                       const CaptureCliOptions& options) {
+  if (options.capture_directory.has_value()) {
+    settings.capture_directory = *options.capture_directory;
+  }
+  if (options.capture_name.has_value()) {
+    settings.capture_name = *options.capture_name;
+  }
+  if (options.decimation_factor.has_value()) {
+    settings.decimation_factor = *options.decimation_factor;
+  }
+  if (options.duration_limit_seconds.has_value()) {
+    settings.duration_limit_seconds = *options.duration_limit_seconds;
+  }
+  if (options.output_format.has_value()) {
+    settings.output_format = *options.output_format;
+  }
+}
+
+bool WantsCoreApplication(int argc, char* argv[]) {
+  for (int index = 1; index < argc; ++index) {
+    const QString token = QString::fromLocal8Bit(argv[index]);
+
+    // Everything after a bare -- is an argument rather than an option, and this
+    // application has none. Stopping here anyway costs nothing and keeps the
+    // scan honest about what an option is.
+    if (token == QLatin1String("--")) {
+      break;
+    }
+
+    if (IsOptionToken(token, kHeadlessName) ||
+        IsOptionToken(token, kStopCaptureName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/capture_cli.h
+++ b/ddd-gui/src/gui/capture_cli.h
@@ -1,0 +1,143 @@
+/************************************************************************
+
+    capture_cli.h
+
+    The capture options the command line accepts, and what they mean
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#pragma once
+
+#include <QCommandLineOption>
+#include <QString>
+#include <optional>
+
+#include "capture_format.h"
+#include "capture_settings.h"
+
+class QCommandLineParser;
+
+namespace ddd::gui {
+
+// What a scripted run exits with.
+//
+// The exit code is the interface: a script that starts a capture, waits for it
+// and moves on reads nothing else, so each of these is a different thing to do
+// about the failure rather than a different way of saying "it did not work".
+// Zero is success everywhere, and 1 is what main() already returns for a
+// command line it could not make sense of.
+enum CaptureCliExit : int {
+  kExitSuccess = 0,
+  kExitBadArguments = 1,
+
+  // Another instance holds the control socket. Two processes streaming from one
+  // device is not something either of them can do, so the second says so rather
+  // than racing for the USB claim.
+  kExitInstanceRunning = 2,
+
+  // Nothing was attached before the wait ran out.
+  kExitNoDevice = 3,
+
+  // A capture started and something went wrong with it. Distinct from the two
+  // above because it is the only one where a file exists to go and look at.
+  kExitCaptureFailed = 4,
+
+  // --stop-capture found nothing to stop.
+  kExitNoRunningInstance = 5,
+};
+
+// Every capture option the command line accepts, kept together so that main()
+// and the tests add exactly the same set.
+//
+// QCommandLineOption has no default constructor, so this is built by
+// AddCaptureCliOptions() below and is never half-populated.
+struct CaptureCliOptionSet {
+  QCommandLineOption start_capture;
+  QCommandLineOption stop_capture;
+  QCommandLineOption headless;
+  QCommandLineOption capture_directory;
+  QCommandLineOption capture_name;
+  QCommandLineOption sample_rate;
+  QCommandLineOption duration_limit;
+  QCommandLineOption output_format;
+};
+
+// Add them to a parser, and hand back the set to read the values out of.
+CaptureCliOptionSet AddCaptureCliOptions(QCommandLineParser& parser);
+
+// What the command line asked for, once it has been made sense of.
+//
+// The attributes are optional rather than pre-filled with the defaults, because
+// "not mentioned" and "asked for, and it happens to be the default" are
+// different instructions: the first leaves the user's saved setting alone and
+// the second overrides it with the same value. A struct of plain values could
+// not tell the two apart.
+struct CaptureCliOptions {
+  bool start_capture = false;
+  bool stop_capture = false;
+  bool headless = false;
+
+  std::optional<QString> capture_directory;
+  std::optional<QString> capture_name;
+
+  // Held as the factor the device is given rather than as the rate the user
+  // typed, because the factor is what a setting is and the rate is how it is
+  // spelled. See capture_format.h.
+  std::optional<int> decimation_factor;
+
+  std::optional<int> duration_limit_seconds;
+  std::optional<capture::CaptureOutputFormat> output_format;
+
+  // Whether anything about the capture itself was named. An attribute given
+  // with no start command is not an error: it populates the window, which is
+  // the "set this up for me and I will press the button" case.
+  bool HasAttributeOverrides() const;
+};
+
+// The options, or the first thing wrong with them.
+//
+// One error rather than a list. The first one is the one a user fixes, and a
+// second complaint about a line that is about to be retyped is noise.
+struct CaptureCliParseResult {
+  CaptureCliOptions options;
+  QString error;
+
+  bool ok() const { return error.isEmpty(); }
+};
+
+// Read the options off a parsed command line and check them over.
+//
+// Checks the combinations as well as the values: --headless without
+// --start-capture is a request to do nothing invisibly, and --stop-capture
+// beside anything else is two instructions for one process, where the second
+// one would be silently dropped.
+CaptureCliParseResult ParseCaptureCliOptions(const QCommandLineParser& parser,
+                                             const CaptureCliOptionSet& set);
+
+// Lay whatever was named over the settings a capture is about to run with.
+//
+// Deliberately a mutation of a value rather than a call on the controller:
+// what the command line says applies to this run and is forgotten, and
+// CaptureController::SetSettings() persists everything it is given. See
+// CaptureController::ApplySessionSettings(), which is the other half of that.
+void ApplyCliOverrides(CaptureSettings& settings,
+                       const CaptureCliOptions& options);
+
+// Whether this command line asks for something that needs no display.
+//
+// Read before any application object exists, because which one to construct is
+// the question it answers: a headless capture and a --stop-capture client both
+// run under a QCoreApplication, and a QApplication would need a platform plugin
+// neither of them has any use for — on a machine with no display, the
+// difference between working and refusing to start.
+//
+// A scan of the raw arguments rather than a parse, since QCommandLineParser
+// needs the application it is about to decide on. It is deliberately literal:
+// it recognises the two switches exactly as the parser accepts them, and
+// anything else it sees is left for the parser to complain about properly.
+bool WantsCoreApplication(int argc, char* argv[]);
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/capture_cli.h
+++ b/ddd-gui/src/gui/capture_cli.h
@@ -33,9 +33,12 @@ enum CaptureCliExit : int {
   kExitSuccess = 0,
   kExitBadArguments = 1,
 
-  // Another instance holds the control socket. Two processes streaming from one
-  // device is not something either of them can do, so the second says so rather
-  // than racing for the USB claim.
+  // The control socket could not be taken, which almost always means another
+  // instance holds it. Two processes streaming from one device is not something
+  // either of them can do, so the second says so rather than racing for the USB
+  // claim — and a run that could not be reached over the socket would be one a
+  // script had no way to stop, so a socket that could not be created at all is
+  // refused here too. The message says which of the two it was.
   kExitInstanceRunning = 2,
 
   // Nothing was attached before the wait ran out.

--- a/ddd-gui/src/gui/capture_control_server.cpp
+++ b/ddd-gui/src/gui/capture_control_server.cpp
@@ -11,7 +11,6 @@
 
 #include "capture_control_server.h"
 
-#include <QAbstractSocket>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
@@ -21,6 +20,8 @@
 #include <QLatin1String>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QStandardPaths>
+#include <QtGlobal>
 
 #include "capture_controller.h"
 #include "logger.h"
@@ -54,6 +55,22 @@ QString ToLine(const QJsonObject& object) {
   return QString::fromUtf8(
              QJsonDocument(object).toJson(QJsonDocument::Compact)) +
          QLatin1Char('\n');
+}
+
+// Whether something is listening on this name and willing to talk. This is the
+// single-instance check, and it is a knock rather than a look at the filesystem
+// because the two things that can be there — a running application and the
+// socket a killed one left behind — are the same file.
+//
+// Nothing to connect to fails at once rather than waiting out the timeout: an
+// absent socket is ENOENT and an absent named pipe is ERROR_FILE_NOT_FOUND, so
+// the ordinary case of starting with nothing running costs nothing.
+bool SomethingIsAnswering(const QString& name) {
+  QLocalSocket probe;
+  probe.connectToServer(name);
+  const bool answered = probe.waitForConnected(kProbeTimeoutMilliseconds);
+  probe.abort();
+  return answered;
 }
 
 std::optional<QJsonObject> ToObject(const QByteArray& line) {
@@ -153,17 +170,57 @@ CaptureControlServer::~CaptureControlServer() {
 
 QString CaptureControlServer::ServerName() {
   // Per user, because the directory a local socket is created in is shared on
-  // some platforms. Two people logged into one machine have two Duplicator
-  // sessions, and the first to start must not be what the second one finds in
-  // the way — nor, with the access bits above, something it could use anyway.
+  // some platforms and a Windows pipe name is shared on every one of them. Two
+  // people logged into one machine have two Duplicator sessions, and the first
+  // to start must not be what the second one finds in the way — nor, with the
+  // access bits above, something it could use anyway.
+  //
+  // Each platform's own variable is asked for first. Both are often set at
+  // once — a Windows shell that came with a Unix toolchain sets USER as well —
+  // and an application started from one kind of shell must land on the same
+  // name as a --stop-capture run from the other.
+#ifdef Q_OS_WIN
+  QString user = qEnvironmentVariable("USERNAME");
+  if (user.isEmpty()) {
+    user = qEnvironmentVariable("USER");
+  }
+#else
   QString user = qEnvironmentVariable("USER");
   if (user.isEmpty()) {
     user = qEnvironmentVariable("USERNAME");
   }
-  if (user.isEmpty()) {
-    return QStringLiteral("ddd-gui-control");
+#endif
+
+  const QString name = user.isEmpty()
+                           ? QStringLiteral("ddd-gui-control")
+                           : QStringLiteral("ddd-gui-control-") + user;
+
+#ifdef Q_OS_WIN
+  // A named pipe, which is not a path and has nowhere to be put.
+  return name;
+#else
+  // An absolute path, so that the socket does not follow TMPDIR.
+  //
+  // A bare name is created in QDir::tempPath(), which honours TMPDIR — and a
+  // shell that sets one is not unusual: a development shell, a systemd unit
+  // with PrivateTmp, a build sandbox. The application and the --stop-capture
+  // run that means to stop it would then be looking in two different places,
+  // and the script would be told nothing was running while a capture was going
+  // on in front of it.
+  //
+  // The runtime directory is the right place for a socket in any case: it is
+  // per user, it is cleaned when the session ends rather than surviving on
+  // disk, and inside a Flatpak it is per application and shared between that
+  // application's instances, which is exactly the reach this needs.
+  const QString runtime =
+      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+  if (runtime.isEmpty()) {
+    // macOS has no such directory, and neither has a stripped-down Linux
+    // session. The temporary directory is where Qt would have put it anyway.
+    return name;
   }
-  return QStringLiteral("ddd-gui-control-") + user;
+  return runtime + QLatin1Char('/') + name;
+#endif
 }
 
 bool CaptureControlServer::Listen(QString* error) {
@@ -175,39 +232,53 @@ bool CaptureControlServer::Listen(const QString& name, QString* error) {
     return true;
   }
 
+  const auto refuse = [error] {
+    if (error != nullptr) {
+      *error = QStringLiteral(
+          "Another Domesday Duplicator is already running. Only one can use "
+          "the device at a time.");
+    }
+    return false;
+  };
+
+  // Knocked on before it is listened on, rather than the other way about, and
+  // this order is what makes the check mean anything on Windows.
+  //
+  // On Unix a second listen() on a socket in use is refused by the operating
+  // system, so asking first is only tidier. On Windows a QLocalServer is a
+  // named pipe, and Qt creates it with PIPE_UNLIMITED_INSTANCES and without
+  // FILE_FLAG_FIRST_PIPE_INSTANCE — so a second process listening on a name
+  // its neighbour already holds *succeeds*, adding another instance of the
+  // same pipe. Both would then believe they were the only one, and a client's
+  // stop would be answered by whichever of them the kernel handed the
+  // connection to, which may be the one that is not capturing.
+  if (SomethingIsAnswering(name)) {
+    return refuse();
+  }
+
   if (server_->listen(name)) {
     RestrictToOwner();
     return true;
   }
 
-  if (server_->serverError() == QAbstractSocket::AddressInUseError) {
-    // Something is there. Whether it is a running application or the remains of
-    // one that was killed is the difference between refusing to start and
-    // starting normally, and the only way to tell is to knock.
-    QLocalSocket probe;
-    probe.connectToServer(name);
-    const bool answered = probe.waitForConnected(kProbeTimeoutMilliseconds);
-    probe.abort();
+  // Nothing answered a moment ago and the name is still taken, which is either
+  // the socket a killed application left behind or an instance that started in
+  // the time between the two. Knocking again is what tells those apart, and
+  // without it the recovery below would delete a live application's socket and
+  // take its place.
+  if (SomethingIsAnswering(name)) {
+    return refuse();
+  }
 
-    if (answered) {
-      if (error != nullptr) {
-        *error = QStringLiteral(
-            "Another Domesday Duplicator is already running. Only one can use "
-            "the device at a time.");
-      }
-      return false;
+  QLocalServer::removeServer(name);
+  if (server_->listen(name)) {
+    RestrictToOwner();
+    if (logger_ != nullptr) {
+      logger_->Info(
+          "Removed a control socket left behind by an application that did "
+          "not shut down.");
     }
-
-    QLocalServer::removeServer(name);
-    if (server_->listen(name)) {
-      RestrictToOwner();
-      if (logger_ != nullptr) {
-        logger_->Info(
-            "Removed a control socket left behind by an application that did "
-            "not shut down.");
-      }
-      return true;
-    }
+    return true;
   }
 
   if (error != nullptr) {

--- a/ddd-gui/src/gui/capture_control_server.cpp
+++ b/ddd-gui/src/gui/capture_control_server.cpp
@@ -1,0 +1,354 @@
+/************************************************************************
+
+    capture_control_server.cpp
+
+    The socket a script stops a running capture through
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include "capture_control_server.h"
+
+#include <QAbstractSocket>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QJsonValue>
+#include <QLatin1String>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+#include "capture_controller.h"
+#include "logger.h"
+
+namespace ddd::gui {
+namespace {
+
+constexpr const char* kVerbKey = "verb";
+constexpr const char* kOkKey = "ok";
+constexpr const char* kFileKey = "file";
+constexpr const char* kBytesKey = "bytes";
+constexpr const char* kErrorKey = "error";
+
+// How long to wait for something to answer on a socket that is already there.
+// Short, and deliberately: this runs before a scripted capture can start, and
+// the case it covers is a socket left behind by an instance that was killed —
+// which answers immediately by not answering at all.
+constexpr int kProbeTimeoutMilliseconds = 250;
+
+// How long to wait for a reply to reach the client. The reply is one short
+// line, so this only matters when the process is about to exit and the bytes
+// have nowhere to be pushed from afterwards.
+constexpr int kFlushTimeoutMilliseconds = 1000;
+
+// A request is one short line. Anything beyond this is not a request that got
+// split up, it is something that is never going to end, and a buffer that grew
+// to meet it would be a way to spend this application's memory from outside it.
+constexpr int kMaximumRequestBytes = 4096;
+
+QString ToLine(const QJsonObject& object) {
+  return QString::fromUtf8(
+             QJsonDocument(object).toJson(QJsonDocument::Compact)) +
+         QLatin1Char('\n');
+}
+
+std::optional<QJsonObject> ToObject(const QByteArray& line) {
+  QJsonParseError parse_error;
+  const QJsonDocument document = QJsonDocument::fromJson(line, &parse_error);
+  if (parse_error.error != QJsonParseError::NoError || !document.isObject()) {
+    return std::nullopt;
+  }
+  return document.object();
+}
+
+}  // namespace
+
+// --- The protocol ---------------------------------------------------------
+
+QString FormatControlRequest(const QString& verb) {
+  QJsonObject object;
+  object.insert(QLatin1String(kVerbKey), verb);
+  return ToLine(object);
+}
+
+std::optional<QString> ParseControlVerb(const QByteArray& line) {
+  const std::optional<QJsonObject> object = ToObject(line);
+  if (!object.has_value()) {
+    return std::nullopt;
+  }
+
+  const QJsonValue verb = object->value(QLatin1String(kVerbKey));
+  if (!verb.isString() || verb.toString().isEmpty()) {
+    return std::nullopt;
+  }
+  return verb.toString();
+}
+
+QString FormatControlReplyStopped(const QString& file_path, quint64 bytes) {
+  QJsonObject object;
+  object.insert(QLatin1String(kOkKey), true);
+  object.insert(QLatin1String(kFileKey), file_path);
+  object.insert(QLatin1String(kBytesKey), static_cast<qint64>(bytes));
+  return ToLine(object);
+}
+
+QString FormatControlReplyError(const QString& message) {
+  QJsonObject object;
+  object.insert(QLatin1String(kOkKey), false);
+  object.insert(QLatin1String(kErrorKey), message);
+  return ToLine(object);
+}
+
+std::optional<ControlReply> ParseControlReply(const QByteArray& line) {
+  const std::optional<QJsonObject> object = ToObject(line);
+  if (!object.has_value()) {
+    return std::nullopt;
+  }
+
+  const QJsonValue ok = object->value(QLatin1String(kOkKey));
+  if (!ok.isBool()) {
+    return std::nullopt;
+  }
+
+  ControlReply reply;
+  reply.ok = ok.toBool();
+  reply.file_path = object->value(QLatin1String(kFileKey)).toString();
+  reply.bytes =
+      static_cast<quint64>(object->value(QLatin1String(kBytesKey)).toInteger());
+  reply.error = object->value(QLatin1String(kErrorKey)).toString();
+  return reply;
+}
+
+// --- The server -----------------------------------------------------------
+
+CaptureControlServer::CaptureControlServer(CaptureController* controller,
+                                           capture::ILogger* logger,
+                                           QObject* parent)
+    : QObject(parent),
+      controller_(controller),
+      logger_(logger),
+      server_(new QLocalServer(this)) {
+  // Deliberately the default socket options, and not UserAccessOption, which
+  // is what this would otherwise want: with it set, a second listen() on a name
+  // an application is already listening on *succeeds*, replacing the first
+  // one's socket rather than failing with AddressInUseError. That would take
+  // the single-instance check below apart — two instances would both believe
+  // they were the only one, and the first would be left listening on a socket
+  // no client could reach. With the default options the operating system's own
+  // exclusion applies and a second listen is refused, which is the behaviour
+  // being relied on here. RestrictToOwner() puts the access bits back.
+  connect(server_, &QLocalServer::newConnection, this,
+          &CaptureControlServer::OnNewConnection);
+}
+
+CaptureControlServer::~CaptureControlServer() {
+  // Explicitly, so the socket is taken out of the filesystem now rather than
+  // whenever the object graph unwinds. The next instance to start looks for it.
+  server_->close();
+}
+
+QString CaptureControlServer::ServerName() {
+  // Per user, because the directory a local socket is created in is shared on
+  // some platforms. Two people logged into one machine have two Duplicator
+  // sessions, and the first to start must not be what the second one finds in
+  // the way — nor, with the access bits above, something it could use anyway.
+  QString user = qEnvironmentVariable("USER");
+  if (user.isEmpty()) {
+    user = qEnvironmentVariable("USERNAME");
+  }
+  if (user.isEmpty()) {
+    return QStringLiteral("ddd-gui-control");
+  }
+  return QStringLiteral("ddd-gui-control-") + user;
+}
+
+bool CaptureControlServer::Listen(QString* error) {
+  return Listen(ServerName(), error);
+}
+
+bool CaptureControlServer::Listen(const QString& name, QString* error) {
+  if (server_->isListening()) {
+    return true;
+  }
+
+  if (server_->listen(name)) {
+    RestrictToOwner();
+    return true;
+  }
+
+  if (server_->serverError() == QAbstractSocket::AddressInUseError) {
+    // Something is there. Whether it is a running application or the remains of
+    // one that was killed is the difference between refusing to start and
+    // starting normally, and the only way to tell is to knock.
+    QLocalSocket probe;
+    probe.connectToServer(name);
+    const bool answered = probe.waitForConnected(kProbeTimeoutMilliseconds);
+    probe.abort();
+
+    if (answered) {
+      if (error != nullptr) {
+        *error = QStringLiteral(
+            "Another Domesday Duplicator is already running. Only one can use "
+            "the device at a time.");
+      }
+      return false;
+    }
+
+    QLocalServer::removeServer(name);
+    if (server_->listen(name)) {
+      RestrictToOwner();
+      if (logger_ != nullptr) {
+        logger_->Info(
+            "Removed a control socket left behind by an application that did "
+            "not shut down.");
+      }
+      return true;
+    }
+  }
+
+  if (error != nullptr) {
+    *error = QStringLiteral("The control socket could not be created: %1")
+                 .arg(server_->errorString());
+  }
+  return false;
+}
+
+void CaptureControlServer::RestrictToOwner() {
+  const QString path = server_->fullServerName();
+  if (path.isEmpty()) {
+    return;
+  }
+
+  // The access bits the default socket options did not set: owner only, so
+  // that nothing belonging to another account on this machine can stop a
+  // capture. The name is per-user as well — see ServerName() — so this is the
+  // second of two locks rather than the only one.
+  //
+  // A Unix socket is a file and this applies to it. A Windows named pipe is not
+  // a file and this does nothing, which is why the failure is only reported for
+  // a name that exists in the filesystem: on Windows there is nothing here to
+  // report, and a warning every run would be noise about a platform difference
+  // rather than about a problem.
+  if (!QFile::setPermissions(
+          path, QFileDevice::ReadOwner | QFileDevice::WriteOwner) &&
+      QFileInfo::exists(path) && logger_ != nullptr) {
+    logger_->Warning(
+        "The control socket could not be restricted to this user: " +
+        path.toStdString());
+  }
+}
+
+bool CaptureControlServer::listening() const { return server_->isListening(); }
+
+QString CaptureControlServer::name() const {
+  return server_->isListening() ? server_->serverName() : QString();
+}
+
+void CaptureControlServer::OnNewConnection() {
+  while (QLocalSocket* socket = server_->nextPendingConnection()) {
+    partial_.insert(socket, QByteArray());
+
+    connect(socket, &QLocalSocket::readyRead, this,
+            [this, socket] { OnReadyRead(socket); });
+
+    connect(socket, &QLocalSocket::disconnected, this, [this, socket] {
+      Forget(socket);
+      socket->deleteLater();
+    });
+  }
+}
+
+void CaptureControlServer::OnReadyRead(QLocalSocket* socket) {
+  QByteArray& buffered = partial_[socket];
+  buffered.append(socket->readAll());
+
+  qsizetype newline = buffered.indexOf('\n');
+  while (newline >= 0) {
+    const QByteArray line = buffered.left(newline);
+    buffered.remove(0, newline + 1);
+    HandleRequest(socket, line);
+    newline = buffered.indexOf('\n');
+  }
+
+  if (buffered.size() > kMaximumRequestBytes) {
+    Reply(socket,
+          FormatControlReplyError(QStringLiteral("That is not a request.")));
+    socket->disconnectFromServer();
+  }
+}
+
+void CaptureControlServer::HandleRequest(QLocalSocket* socket,
+                                         const QByteArray& line) {
+  const std::optional<QString> verb = ParseControlVerb(line);
+  if (!verb.has_value()) {
+    Reply(socket,
+          FormatControlReplyError(QStringLiteral("That is not a request.")));
+    return;
+  }
+
+  if (*verb == QLatin1String(kStopVerb)) {
+    HandleStop(socket);
+    return;
+  }
+
+  // Answered rather than ignored: a client asking for something this build does
+  // not do should be told so, not left waiting for a reply that is not coming.
+  Reply(socket, FormatControlReplyError(
+                    QStringLiteral("Unknown request '%1'.").arg(*verb)));
+}
+
+void CaptureControlServer::HandleStop(QLocalSocket* socket) {
+  if (controller_ == nullptr || !controller_->capturing()) {
+    Reply(socket,
+          FormatControlReplyError(QStringLiteral("No capture is running.")));
+    return;
+  }
+
+  // Connected before the capture is asked to stop, and to CaptureFinished
+  // rather than to CapturingChanged. Stopping detaches the writer immediately
+  // and says so, but the file is not finished at that point: the encoder has
+  // yet to close it, the capture may still be renamed to carry its duration,
+  // and the sidecar has not been written. The path in the reply is the one that
+  // is actually on disk, so it is the later signal that carries it.
+  //
+  // The socket is the context object, so a client that gave up and closed the
+  // connection takes this connection with it rather than leaving a reply
+  // addressed to nothing.
+  connect(
+      controller_, &CaptureController::CaptureFinished, socket,
+      [this, socket](const QString& file_path, quint64 bytes) {
+        Reply(socket, FormatControlReplyStopped(file_path, bytes));
+      },
+      Qt::SingleShotConnection);
+
+  if (logger_ != nullptr) {
+    logger_->Info("Stopping the capture: asked over the control socket.");
+  }
+
+  controller_->StopCapture();
+}
+
+void CaptureControlServer::Forget(QLocalSocket* socket) {
+  partial_.remove(socket);
+}
+
+void CaptureControlServer::Reply(QLocalSocket* socket, const QString& line) {
+  if (socket == nullptr || socket->state() != QLocalSocket::ConnectedState) {
+    return;
+  }
+
+  socket->write(line.toUtf8());
+  socket->flush();
+
+  // A headless run quits as soon as the capture it was asked to stop has
+  // finished, which can be the same turn of the event loop this reply is
+  // written in. Pushed out here, rather than left in a buffer belonging to a
+  // socket that is about to be destroyed along with everything else.
+  socket->waitForBytesWritten(kFlushTimeoutMilliseconds);
+}
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/capture_control_server.h
+++ b/ddd-gui/src/gui/capture_control_server.h
@@ -1,0 +1,150 @@
+/************************************************************************
+
+    capture_control_server.h
+
+    The socket a script stops a running capture through
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#pragma once
+
+#include <QByteArray>
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QtGlobal>
+#include <optional>
+
+class QLocalServer;
+class QLocalSocket;
+
+namespace ddd::capture {
+class ILogger;
+}  // namespace ddd::capture
+
+namespace ddd::gui {
+
+class CaptureController;
+
+// --- The protocol ---------------------------------------------------------
+//
+// One JSON object per line, in both directions:
+//
+//   request   {"verb":"stop"}
+//   reply     {"ok":true,"file":"/captures/disc-1.ddd.flac","bytes":123456}
+//             {"ok":false,"error":"No capture is running."}
+//
+// JSON rather than a bare word and a path, for one reason that matters: the
+// reply carries a file name a user chose, and a protocol that separated fields
+// by spaces would be wrong the first time somebody captured a disc whose title
+// has a space in it. Escaping is the whole job, and QJsonDocument does it.
+//
+// Formatted and parsed by free functions so that both halves can be tested
+// without a socket, a server or an event loop between them.
+
+// The only thing a client can ask for. An unknown verb is answered with an
+// error rather than ignored, so that a newer client talking to an older
+// application is told, instead of waiting for a reply that is never coming.
+inline constexpr const char* kStopVerb = "stop";
+
+// A request line, terminated. Never empty.
+QString FormatControlRequest(const QString& verb);
+
+// The verb from a request line, or nothing when the line was not a request
+// this application understands.
+std::optional<QString> ParseControlVerb(const QByteArray& line);
+
+QString FormatControlReplyStopped(const QString& file_path, quint64 bytes);
+QString FormatControlReplyError(const QString& message);
+
+// A reply, as the client reads it. `ok` false means the request was understood
+// and refused, which is a different thing from a line that could not be parsed
+// at all — that is a missing optional from ParseControlReply().
+struct ControlReply {
+  bool ok = false;
+  QString file_path;
+  quint64 bytes = 0;
+  QString error;
+};
+
+std::optional<ControlReply> ParseControlReply(const QByteArray& line);
+
+// --- The server -----------------------------------------------------------
+
+// Listens for the one instruction a running application takes from outside
+// itself: stop the capture.
+//
+// Every instance holds one of these, windowed or not, so that a capture started
+// from a script and a capture started by hand are stopped the same way. The
+// socket is local — a Unix domain socket or a named pipe, never a network one —
+// so nothing off this machine can reach it, and it is created with user-only
+// access so nothing belonging to another user can either.
+//
+// Listening doubles as the single-instance check. Two processes streaming from
+// one device is not something either of them can do, so a scripted start that
+// finds the socket taken says so and exits rather than racing for the USB
+// claim. That is why Listen() reports failure rather than merely logging it.
+class CaptureControlServer : public QObject {
+  Q_OBJECT
+
+ public:
+  CaptureControlServer(CaptureController* controller, capture::ILogger* logger,
+                       QObject* parent = nullptr);
+  ~CaptureControlServer() override;
+
+  // The socket every instance uses, and the one --stop-capture looks for.
+  //
+  // Per user, because the directory the socket is created in may be shared:
+  // two people logged into one machine each have their own Duplicator session,
+  // and neither should find the other's socket in the way.
+  static QString ServerName();
+
+  // Start listening. False means another instance is already running — or, for
+  // any other failure, that the socket could not be created at all; `error`
+  // says which, in words meant for a user.
+  //
+  // A socket left behind by an instance that was killed is recovered from
+  // rather than treated as a live one: it is probed first, and only removed
+  // when nothing answers.
+  bool Listen(QString* error);
+
+  // The same, on a name of the test's choosing. Two test processes running at
+  // once must not share a socket, and neither may touch the one a real
+  // application is listening on.
+  bool Listen(const QString& name, QString* error);
+
+  bool listening() const;
+
+  // The name being listened on, or empty. For the tests and the log.
+  QString name() const;
+
+ private:
+  void OnNewConnection();
+  void OnReadyRead(QLocalSocket* socket);
+  void HandleRequest(QLocalSocket* socket, const QByteArray& line);
+  void HandleStop(QLocalSocket* socket);
+  void Forget(QLocalSocket* socket);
+
+  // Take the socket's access bits down to this user, once it exists.
+  void RestrictToOwner();
+
+  // Write one line and make sure it leaves. A headless run quits as soon as the
+  // capture it was asked to stop has finished, which can be within the same
+  // turn of the event loop as this reply — so the bytes are pushed out here
+  // rather than left for a socket that is about to be destroyed.
+  void Reply(QLocalSocket* socket, const QString& line);
+
+  CaptureController* controller_ = nullptr;
+  capture::ILogger* logger_ = nullptr;
+  QLocalServer* server_ = nullptr;
+
+  // What has arrived on each connection but is not yet a whole line. A request
+  // is one short line and almost always arrives in one piece, but "almost
+  // always" is not something a protocol may be written against.
+  QHash<QLocalSocket*, QByteArray> partial_;
+};
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/capture_control_server.h
+++ b/ddd-gui/src/gui/capture_control_server.h
@@ -97,18 +97,23 @@ class CaptureControlServer : public QObject {
 
   // The socket every instance uses, and the one --stop-capture looks for.
   //
-  // Per user, because the directory the socket is created in may be shared:
-  // two people logged into one machine each have their own Duplicator session,
-  // and neither should find the other's socket in the way.
+  // Per user, because the place the socket is created in may be shared: two
+  // people logged into one machine each have their own Duplicator session, and
+  // neither should find the other's socket in the way.
+  //
+  // On Unix this is an absolute path in the session's runtime directory rather
+  // than a bare name, which would be created under TMPDIR and so would differ
+  // between two shells that ought to be able to reach each other.
   static QString ServerName();
 
   // Start listening. False means another instance is already running — or, for
   // any other failure, that the socket could not be created at all; `error`
   // says which, in words meant for a user.
   //
-  // A socket left behind by an instance that was killed is recovered from
-  // rather than treated as a live one: it is probed first, and only removed
-  // when nothing answers.
+  // The name is knocked on before it is listened on, so that a socket left
+  // behind by an instance that was killed is recovered from rather than
+  // treated as a live one — and so that the check works on Windows, where
+  // listening on a name in use succeeds rather than failing.
   bool Listen(QString* error);
 
   // The same, on a name of the test's choosing. Two test processes running at

--- a/ddd-gui/src/gui/capture_controller.cpp
+++ b/ddd-gui/src/gui/capture_controller.cpp
@@ -630,8 +630,22 @@ void CaptureController::FinishCaptureFile(const capture::CaptureStats& stats,
   if (settings_.naming.append_duration && duration_seconds > 0.0) {
     const std::string suffix = capture::MatchedCaptureFileSuffix(file.string());
     const std::string base = capture::StripCaptureFileSuffix(file.string());
-    const std::filesystem::path renamed(
+    const std::filesystem::path wanted(
         capture::AppendDurationToStem(base, duration_seconds) + suffix);
+
+    // Made unique here as well, and for the same reason it was made unique
+    // before the file was opened.
+    //
+    // The uniqueness settled at the open is about the name without the
+    // duration, and this is a different name — so a capture that took the same
+    // length as an earlier one of the same name arrives at a destination that
+    // is already occupied. std::filesystem::rename replaces whatever is there
+    // without a word, which would destroy a finished recording to tidy up a
+    // file name. That is not a rare shape: it is exactly what a script that
+    // captures with a fixed --capture-name and a fixed --duration-limit
+    // produces every time it runs.
+    const std::filesystem::path renamed =
+        capture::MakeUniqueCapturePath(wanted);
 
     std::error_code error;
     std::filesystem::rename(file, renamed, error);
@@ -644,6 +658,17 @@ void CaptureController::FinishCaptureFile(const capture::CaptureStats& stats,
                          renamed.string() + ": " + error.message());
       }
     } else {
+      if (renamed != wanted) {
+        // The same thing the open says when it happens there, and it has to be
+        // said here too: the file is not the one the naming asked for, and
+        // nobody watching would otherwise know.
+        emit CaptureRenamed(
+            QString::fromStdString(
+                capture::StripCaptureFileSuffix(wanted.filename().string())),
+            QString::fromStdString(
+                capture::StripCaptureFileSuffix(renamed.filename().string())));
+      }
+
       file = renamed;
       capture_path_ = QString::fromStdString(file.string());
       pending_metadata_.capture_file_name = file.filename().string();

--- a/ddd-gui/src/gui/capture_controller.cpp
+++ b/ddd-gui/src/gui/capture_controller.cpp
@@ -119,6 +119,11 @@ void CaptureController::SetSettings(const CaptureSettings& settings) {
   emit SettingsChanged(settings_);
 }
 
+void CaptureController::ApplySessionSettings(const CaptureSettings& settings) {
+  settings_ = settings;
+  emit SettingsChanged(settings_);
+}
+
 void CaptureController::SetDiscProvenance(const capture::DiscProvenance& disc) {
   disc_provenance_ = disc;
 }

--- a/ddd-gui/src/gui/capture_controller.h
+++ b/ddd-gui/src/gui/capture_controller.h
@@ -195,9 +195,14 @@ class CaptureController : public QObject {
   void CapturingChanged(bool capturing, const QString& file_path);
 
   // The requested name was already taken, so the capture was written under
-  // another. Not a failure — nothing was overwritten, which the engine
-  // guarantees by resolving the path before it opens anything — but a fact the
-  // user has to be told, because the file is not the one they named.
+  // another. Not a failure — nothing was overwritten — but a fact the user has
+  // to be told, because the file is not the one they named.
+  //
+  // Emitted at either of the two moments a capture is named: before the file
+  // is opened, and again at the end if the naming appends the capture's length
+  // and *that* name is taken as well. The second is what a script produces
+  // every run when it captures with a fixed name and a fixed duration limit,
+  // so it is not the unlikely half of this.
   void CaptureRenamed(const QString& requested, const QString& written);
 
   // A capture finished and its file is closed. `bytes` is what reached the

--- a/ddd-gui/src/gui/capture_controller.h
+++ b/ddd-gui/src/gui/capture_controller.h
@@ -143,6 +143,18 @@ class CaptureController : public QObject {
   // running transfer.
   void SetSettings(const CaptureSettings& settings);
 
+  // The same, without saving them.
+  //
+  // What the command line names applies to the run it was given to and is then
+  // forgotten: a script that captures one disc at 20 Msps has not asked for
+  // every capture afterwards to be taken at 20 Msps, and SetSettings() above
+  // would have made that the user's new saved answer. The window is populated
+  // from what this sets, so a capture set up from a script and then taken by
+  // hand still runs with what the script asked for — and if the user then edits
+  // any of it in the panel, that edit saves in the ordinary way, because at
+  // that point it is their choice rather than the script's.
+  void ApplySessionSettings(const CaptureSettings& settings);
+
   // How often the statistics are republished to the panels. 20 Hz: fast enough
   // that a throughput reading looks live, slow enough that it is nowhere near
   // the cost of anything else the application does.

--- a/ddd-gui/src/gui/capture_stop_client.cpp
+++ b/ddd-gui/src/gui/capture_stop_client.cpp
@@ -1,0 +1,138 @@
+/************************************************************************
+
+    capture_stop_client.cpp
+
+    --stop-capture, the other end of the control socket
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include "capture_stop_client.h"
+
+#include <QByteArray>
+#include <QEventLoop>
+#include <QLocalSocket>
+#include <QTextStream>
+#include <QTimer>
+#include <optional>
+
+#include "capture_cli.h"
+#include "capture_control_server.h"
+
+namespace ddd::gui {
+
+int RunStopCapture(QTextStream& out, QTextStream& error,
+                   const StopCaptureOptions& options) {
+  const QString name = options.server_name.isEmpty()
+                           ? CaptureControlServer::ServerName()
+                           : options.server_name;
+
+  QLocalSocket socket;
+  QEventLoop loop;
+  QTimer deadline;
+  deadline.setSingleShot(true);
+
+  QByteArray buffered;
+  int code = kExitNoRunningInstance;
+  bool settled = false;
+  bool connected = false;
+
+  // Everything below reaches an answer exactly once. The socket has several
+  // ways to end — a reply, a close, an error, a timeout — and more than one of
+  // them can happen: a server that replies and then closes would otherwise
+  // overwrite a success with the disconnection that followed it.
+  const auto settle = [&](int result) {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    code = result;
+    loop.quit();
+  };
+
+  QObject::connect(&socket, &QLocalSocket::connected, &socket, [&] {
+    connected = true;
+    deadline.start(options.reply_timeout_milliseconds);
+    socket.write(FormatControlRequest(QLatin1String(kStopVerb)).toUtf8());
+    socket.flush();
+  });
+
+  QObject::connect(&socket, &QLocalSocket::readyRead, &socket, [&] {
+    buffered.append(socket.readAll());
+    const qsizetype newline = buffered.indexOf('\n');
+    if (newline < 0) {
+      return;
+    }
+
+    const std::optional<ControlReply> reply =
+        ParseControlReply(buffered.left(newline));
+    if (!reply.has_value()) {
+      error << "Error: the running application answered with something that "
+               "could not be understood.\n";
+      settle(kExitCaptureFailed);
+      return;
+    }
+
+    if (!reply->ok) {
+      error << "Error: " << reply->error << "\n";
+      settle(kExitCaptureFailed);
+      return;
+    }
+
+    // The path alone, so that a script can use what it reads without having to
+    // take it apart. The size is worth saying to whoever is watching, and it
+    // goes to the other stream for exactly that reason.
+    out << reply->file_path << "\n";
+    error << "Stopped. " << QString::number(reply->bytes)
+          << " bytes written.\n";
+    settle(kExitSuccess);
+  });
+
+  QObject::connect(&socket, &QLocalSocket::errorOccurred, &socket,
+                   [&](QLocalSocket::LocalSocketError) {
+                     if (!connected) {
+                       error << "There is no Domesday Duplicator running to "
+                                "stop.\n";
+                       settle(kExitNoRunningInstance);
+                       return;
+                     }
+                     error << "Error: the connection to the running "
+                              "application failed before it answered.\n";
+                     settle(kExitCaptureFailed);
+                   });
+
+  QObject::connect(&socket, &QLocalSocket::disconnected, &socket, [&] {
+    error << "Error: the running application closed the connection without "
+             "answering.\n";
+    settle(kExitCaptureFailed);
+  });
+
+  QObject::connect(&deadline, &QTimer::timeout, &deadline, [&] {
+    if (!connected) {
+      error << "There is no Domesday Duplicator running to stop.\n";
+      settle(kExitNoRunningInstance);
+      return;
+    }
+    error << "Error: the capture was asked to stop, but the application did "
+             "not say it had finished the file.\n";
+    settle(kExitCaptureFailed);
+  });
+
+  deadline.start(options.connect_timeout_milliseconds);
+  socket.connectToServer(name);
+
+  // A connection that failed before there was an event loop to report it in has
+  // already settled, and exec() would then wait for a quit() that has been and
+  // gone.
+  if (!settled) {
+    loop.exec();
+  }
+
+  out.flush();
+  error.flush();
+  return code;
+}
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/capture_stop_client.cpp
+++ b/ddd-gui/src/gui/capture_stop_client.cpp
@@ -43,6 +43,11 @@ int RunStopCapture(QTextStream& out, QTextStream& error,
   // ways to end — a reply, a close, an error, a timeout — and more than one of
   // them can happen: a server that replies and then closes would otherwise
   // overwrite a success with the disconnection that followed it.
+  //
+  // That is not a rare case. A headless run exits the moment the capture it was
+  // asked to stop has finished, which is the moment after this reply, so the
+  // disconnection arrives in the same turn of the event loop as the answer
+  // nearly every time.
   const auto settle = [&](int result) {
     if (settled) {
       return;
@@ -52,6 +57,13 @@ int RunStopCapture(QTextStream& out, QTextStream& error,
     loop.quit();
   };
 
+  // Whether an answer has already been reached, checked before *saying*
+  // anything rather than only before recording it. Quitting the loop does not
+  // take effect until control returns to exec(), so the handlers for whatever
+  // else the socket does still run — and a message printed from one of them
+  // would tell a user their successful stop had failed.
+  const auto answered = [&settled] { return settled; };
+
   QObject::connect(&socket, &QLocalSocket::connected, &socket, [&] {
     connected = true;
     deadline.start(options.reply_timeout_milliseconds);
@@ -60,6 +72,9 @@ int RunStopCapture(QTextStream& out, QTextStream& error,
   });
 
   QObject::connect(&socket, &QLocalSocket::readyRead, &socket, [&] {
+    if (answered()) {
+      return;
+    }
     buffered.append(socket.readAll());
     const qsizetype newline = buffered.indexOf('\n');
     if (newline < 0) {
@@ -92,6 +107,9 @@ int RunStopCapture(QTextStream& out, QTextStream& error,
 
   QObject::connect(&socket, &QLocalSocket::errorOccurred, &socket,
                    [&](QLocalSocket::LocalSocketError) {
+                     if (answered()) {
+                       return;
+                     }
                      if (!connected) {
                        error << "There is no Domesday Duplicator running to "
                                 "stop.\n";
@@ -104,12 +122,18 @@ int RunStopCapture(QTextStream& out, QTextStream& error,
                    });
 
   QObject::connect(&socket, &QLocalSocket::disconnected, &socket, [&] {
+    if (answered()) {
+      return;
+    }
     error << "Error: the running application closed the connection without "
              "answering.\n";
     settle(kExitCaptureFailed);
   });
 
   QObject::connect(&deadline, &QTimer::timeout, &deadline, [&] {
+    if (answered()) {
+      return;
+    }
     if (!connected) {
       error << "There is no Domesday Duplicator running to stop.\n";
       settle(kExitNoRunningInstance);

--- a/ddd-gui/src/gui/capture_stop_client.h
+++ b/ddd-gui/src/gui/capture_stop_client.h
@@ -1,0 +1,53 @@
+/************************************************************************
+
+    capture_stop_client.h
+
+    --stop-capture, the other end of the control socket
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#pragma once
+
+#include <QString>
+
+class QTextStream;
+
+namespace ddd::gui {
+
+struct StopCaptureOptions {
+  // Empty means the socket every instance listens on. The tests name their own,
+  // so that one running here cannot reach an application running on the bench.
+  QString server_name;
+
+  int connect_timeout_milliseconds = 3000;
+
+  // Generous, and it is not a guess at how long stopping takes. Stopping is the
+  // encoder finishing a file: on a slow disk, at the end of a disc side, that
+  // is as long as it is, and a client that gave up early would report a failure
+  // for a capture that was about to be written perfectly well.
+  int reply_timeout_milliseconds = 60000;
+};
+
+// Ask the running application to stop its capture, and wait until the file is
+// finished.
+//
+// The waiting is the point. A script that stops a capture and immediately reads
+// the file needs the file to be closed, the duration rename to have happened
+// and the sidecar to be written — none of which is true when the capture stops,
+// only when it has finished. This returns after all of it.
+//
+// The path of the finished capture goes to stdout, alone and unadorned, so that
+// a script can take it as it stands; everything meant for a person reading
+// along goes to stderr. Returns a CaptureCliExit code: success, nothing running
+// to stop, or a stop that did not produce a file.
+//
+// Driven by an event loop rather than QLocalSocket's blocking waits, so that a
+// test can host the server on the same thread as the client and have the two
+// talk to each other.
+int RunStopCapture(QTextStream& out, QTextStream& error,
+                   const StopCaptureOptions& options = {});
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/console_attach.cpp
+++ b/ddd-gui/src/gui/console_attach.cpp
@@ -21,6 +21,27 @@ namespace ddd::gui {
 
 #ifdef _WIN32
 
+namespace {
+
+// Whether the caller pointed this stream somewhere of its own — `> file`, or a
+// pipe into another command — rather than leaving it to the console.
+//
+// Asked of the handle rather than of the process, because a windowed
+// application started from a command prompt has no console but does have
+// whatever handles the prompt passed it: a redirection is set up before the
+// process starts, and the C runtime binds the stream to it at startup whatever
+// subsystem the executable was linked for.
+bool Redirected(HANDLE handle) {
+  if (handle == nullptr || handle == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+  const DWORD type =
+      GetFileType(handle) & ~static_cast<DWORD>(FILE_TYPE_REMOTE);
+  return type == FILE_TYPE_DISK || type == FILE_TYPE_PIPE;
+}
+
+}  // namespace
+
 bool AttachParentConsole() {
   // A console this process already owns — a developer build linked without
   // WIN32_EXECUTABLE, or a second call — is left alone. Attaching over it
@@ -28,6 +49,11 @@ bool AttachParentConsole() {
   if (GetConsoleWindow() != nullptr) {
     return true;
   }
+
+  // Asked before attaching, because attaching is entitled to replace the
+  // process's standard handles with the console's own.
+  const bool stdout_redirected = Redirected(GetStdHandle(STD_OUTPUT_HANDLE));
+  const bool stderr_redirected = Redirected(GetStdHandle(STD_ERROR_HANDLE));
 
   if (AttachConsole(ATTACH_PARENT_PROCESS) == 0) {
     return false;
@@ -38,13 +64,16 @@ bool AttachParentConsole() {
   // reopened onto the console's own device name. Without this the console
   // exists and every write still goes nowhere.
   //
-  // Both are attempted whatever the other does. A stream that will not reopen
-  // has almost certainly been redirected to a file by the caller, which is a
-  // use of the console this does not need to understand and has no business
-  // overriding — and standard input is left alone entirely, because a windowed
-  // application reads none.
-  const bool have_stdout = std::freopen("CONOUT$", "w", stdout) != nullptr;
-  const bool have_stderr = std::freopen("CONOUT$", "w", stderr) != nullptr;
+  // A stream the caller redirected is left exactly as it was found. Reopening
+  // that one onto the console would take a script's output away from the file
+  // or the pipe it asked for and put it on the screen instead — which is the
+  // whole of `ddd-gui --stop-capture > path.txt`, and the one thing this
+  // function must not do. Standard input is left alone in every case, because
+  // a windowed application reads none.
+  const bool have_stdout =
+      stdout_redirected || std::freopen("CONOUT$", "w", stdout) != nullptr;
+  const bool have_stderr =
+      stderr_redirected || std::freopen("CONOUT$", "w", stderr) != nullptr;
 
   return have_stdout || have_stderr;
 }

--- a/ddd-gui/src/gui/headless_capture_runner.cpp
+++ b/ddd-gui/src/gui/headless_capture_runner.cpp
@@ -1,0 +1,302 @@
+/************************************************************************
+
+    headless_capture_runner.cpp
+
+    A capture with no window around it, from start to finished file
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include "headless_capture_runner.h"
+
+#include <QMetaObject>
+#include <QTextStream>
+#include <memory>
+
+#include "capture_controller.h"
+
+namespace ddd::gui {
+
+void StartCaptureWhenDeviceAppears(CaptureController* controller) {
+  if (controller == nullptr) {
+    return;
+  }
+
+  if (!controller->devices().empty()) {
+    controller->StartCapture();
+    return;
+  }
+
+  // Held through a shared pointer so that the connection can name itself: the
+  // handler has to disconnect the very connection it is running in, and Qt has
+  // no other way to say that. Qt::SingleShotConnection would say it in one word
+  // and say the wrong thing — it is spent on the first report of any kind, and
+  // the first report is nearly always the empty one.
+  auto connection = std::make_shared<QMetaObject::Connection>();
+  *connection = QObject::connect(
+      controller, &CaptureController::DevicesChanged, controller,
+      [controller,
+       connection](const std::vector<capture::DeviceInfo>& devices) {
+        if (devices.empty()) {
+          return;
+        }
+        QObject::disconnect(*connection);
+        controller->StartCapture();
+      });
+}
+
+HeadlessCaptureRunner::HeadlessCaptureRunner(
+    CaptureController* controller, QTextStream& out, QTextStream& error,
+    const HeadlessCaptureOptions& options, QObject* parent)
+    : QObject(parent),
+      controller_(controller),
+      out_(&out),
+      error_(&error),
+      options_(options) {
+  device_timer_.setSingleShot(true);
+  finish_timer_.setSingleShot(true);
+
+  connect(&device_timer_, &QTimer::timeout, this, [this] {
+    if (state_ != State::kWaitingForDevice) {
+      return;
+    }
+    Say(QStringLiteral(
+            "No Domesday Duplicator was found within %1 seconds. Nothing was "
+            "captured.")
+            .arg(options_.device_wait_milliseconds / 1000));
+    Finish(kExitNoDevice);
+  });
+
+  connect(&finish_timer_, &QTimer::timeout, this, [this] {
+    if (state_ == State::kDone) {
+      return;
+    }
+    Say(QStringLiteral(
+        "The capture was stopped but the file was never reported as finished. "
+        "Whatever was written is on disk and may be incomplete."));
+    Finish(kExitCaptureFailed);
+  });
+}
+
+void HeadlessCaptureRunner::Begin() {
+  if (controller_ == nullptr) {
+    Say(QStringLiteral("There is no capture controller to run."));
+    Finish(kExitCaptureFailed);
+    return;
+  }
+
+  if (state_ != State::kIdle) {
+    return;
+  }
+  state_ = State::kWaitingForDevice;
+
+  connect(controller_, &CaptureController::DevicesChanged, this,
+          &HeadlessCaptureRunner::OnDevicesChanged);
+  connect(controller_, &CaptureController::CapturingChanged, this,
+          &HeadlessCaptureRunner::OnCapturingChanged);
+  connect(controller_, &CaptureController::CaptureFinished, this,
+          &HeadlessCaptureRunner::OnCaptureFinished);
+  connect(controller_, &CaptureController::Failed, this,
+          &HeadlessCaptureRunner::OnFailed);
+
+  // Reported rather than acted on. A capture written under a name other than
+  // the one asked for is not a failure — nothing was overwritten — but a script
+  // that named the file needs to be told, because the name it reads back is not
+  // the one it gave. The path on stdout at the end is the authority.
+  connect(controller_, &CaptureController::CaptureRenamed, this,
+          [this](const QString& requested, const QString& written) {
+            Say(QStringLiteral("'%1' was already taken, so the capture is "
+                               "being written as '%2'.")
+                    .arg(requested, written));
+          });
+
+  connect(controller_, &CaptureController::MetadataWriteFailed, this,
+          [this](const QString& detail) {
+            Say(QStringLiteral("The metadata file could not be written: %1")
+                    .arg(detail));
+          });
+
+  connect(controller_, &CaptureController::LowSpaceWarning, this,
+          [this](const QString& message) { Say(message); });
+
+  if (options_.device_wait_milliseconds > 0) {
+    device_timer_.start(options_.device_wait_milliseconds);
+  }
+
+  // A device that is already there, noticed one turn of the event loop later
+  // rather than now. Begin() is called before exec(), so a capture that failed
+  // to start from inside it would emit Finished() into a loop that had not
+  // begun — and the quit it is connected to would be lost.
+  QMetaObject::invokeMethod(
+      this,
+      [this] {
+        if (state_ != State::kWaitingForDevice || controller_ == nullptr) {
+          return;
+        }
+        if (!controller_->devices().empty()) {
+          StartCapture();
+        }
+      },
+      Qt::QueuedConnection);
+}
+
+void HeadlessCaptureRunner::OnDevicesChanged(
+    const std::vector<capture::DeviceInfo>& devices) {
+  if (state_ != State::kWaitingForDevice || devices.empty()) {
+    return;
+  }
+  StartCapture();
+}
+
+void HeadlessCaptureRunner::StartCapture() {
+  device_timer_.stop();
+  state_ = State::kStarting;
+  controller_->StartCapture();
+
+  // Still starting means the controller neither began a capture nor said why,
+  // which nothing in it does today — CapturingChanged or Failed comes back from
+  // that call. Covered anyway, because the alternative is a headless process
+  // that sits at a prompt forever having captured nothing.
+  if (state_ == State::kStarting) {
+    Say(QStringLiteral("The capture did not start."));
+    Finish(kExitCaptureFailed);
+  }
+}
+
+void HeadlessCaptureRunner::OnCapturingChanged(bool capturing,
+                                               const QString& file_path) {
+  if (state_ == State::kDone) {
+    return;
+  }
+
+  if (capturing) {
+    state_ = State::kCapturing;
+    Say(QStringLiteral("Capturing to %1").arg(file_path));
+    return;
+  }
+
+  if (state_ != State::kCapturing && state_ != State::kStarting) {
+    return;
+  }
+
+  // Every way a capture ends arrives here — the duration limit, an interrupt, a
+  // --stop-capture client, or the stream failing underneath it — so the wait
+  // for the file is armed in one place rather than at each of them.
+  state_ = State::kFinishing;
+  Say(QStringLiteral("Stopped. Finishing the file."));
+  if (options_.finish_wait_milliseconds > 0) {
+    finish_timer_.start(options_.finish_wait_milliseconds);
+  }
+}
+
+void HeadlessCaptureRunner::OnCaptureFinished(const QString& file_path,
+                                              quint64 bytes) {
+  if (state_ == State::kDone) {
+    return;
+  }
+
+  state_ = State::kFinishing;
+  finish_timer_.stop();
+
+  *out_ << file_path << "\n";
+  out_->flush();
+  Say(QStringLiteral("Finished. %1 bytes written.").arg(bytes));
+
+  ScheduleFinish();
+}
+
+void HeadlessCaptureRunner::OnFailed(const QString& title,
+                                     const QString& detail) {
+  if (state_ == State::kDone) {
+    return;
+  }
+
+  Say(QStringLiteral("Error: %1. %2").arg(title, detail));
+  exit_code_ = kExitCaptureFailed;
+
+  // The file is already on its way and the exit code has just been made to say
+  // so. This is the ordering the wait exists for: the controller reports the
+  // finished file and then, in the same call, reports the failure of the run
+  // that produced it.
+  if (finish_scheduled_) {
+    return;
+  }
+
+  if (state_ == State::kCapturing) {
+    // Whatever has been written so far is worth closing properly, and stopping
+    // is how that happens. The finish path takes it from here.
+    controller_->StopCapture();
+    return;
+  }
+
+  if (state_ == State::kFinishing) {
+    return;
+  }
+
+  Finish(exit_code_);
+}
+
+void HeadlessCaptureRunner::RequestStop() {
+  if (state_ == State::kDone) {
+    return;
+  }
+
+  if (state_ == State::kFinishing) {
+    Say(QStringLiteral(
+        "Still finishing the file. Interrupting again will not make it "
+        "quicker, and stopping here would leave it unreadable."));
+    return;
+  }
+
+  if (state_ == State::kCapturing) {
+    Say(QStringLiteral("Interrupted. Stopping the capture."));
+    controller_->StopCapture();
+    return;
+  }
+
+  // Interrupted before anything was captured. Reported as no device, because
+  // that is what a script needs to know: there is no file, and the reason there
+  // is no file is that nothing was ever there to capture from.
+  Say(QStringLiteral(
+      "Interrupted before a device appeared. Nothing was captured."));
+  Finish(kExitNoDevice);
+}
+
+void HeadlessCaptureRunner::ScheduleFinish() {
+  if (finish_scheduled_) {
+    return;
+  }
+  finish_scheduled_ = true;
+
+  QMetaObject::invokeMethod(
+      this, [this] { Finish(exit_code_); }, Qt::QueuedConnection);
+}
+
+void HeadlessCaptureRunner::Finish(int exit_code) {
+  if (state_ == State::kDone) {
+    return;
+  }
+  state_ = State::kDone;
+  device_timer_.stop();
+  finish_timer_.stop();
+
+  out_->flush();
+  error_->flush();
+
+  // Queued, always. Finish() is reachable from Begin() and from a controller
+  // call made before exec(), and a caller that connects this to quit() would
+  // otherwise lose it and wait forever in an event loop it had just been told
+  // to leave.
+  QMetaObject::invokeMethod(
+      this, [this, exit_code] { emit Finished(exit_code); },
+      Qt::QueuedConnection);
+}
+
+void HeadlessCaptureRunner::Say(const QString& line) {
+  *error_ << line << "\n";
+  error_->flush();
+}
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/headless_capture_runner.cpp
+++ b/ddd-gui/src/gui/headless_capture_runner.cpp
@@ -105,12 +105,12 @@ void HeadlessCaptureRunner::Begin() {
   // the one asked for is not a failure — nothing was overwritten — but a script
   // that named the file needs to be told, because the name it reads back is not
   // the one it gave. The path on stdout at the end is the authority.
-  connect(controller_, &CaptureController::CaptureRenamed, this,
-          [this](const QString& requested, const QString& written) {
-            Say(QStringLiteral("'%1' was already taken, so the capture is "
-                               "being written as '%2'.")
-                    .arg(requested, written));
-          });
+  connect(
+      controller_, &CaptureController::CaptureRenamed, this,
+      [this](const QString& requested, const QString& written) {
+        Say(QStringLiteral("'%1' was already taken, so this capture is '%2'.")
+                .arg(requested, written));
+      });
 
   connect(controller_, &CaptureController::MetadataWriteFailed, this,
           [this](const QString& detail) {

--- a/ddd-gui/src/gui/headless_capture_runner.h
+++ b/ddd-gui/src/gui/headless_capture_runner.h
@@ -1,0 +1,167 @@
+/************************************************************************
+
+    headless_capture_runner.h
+
+    A capture with no window around it, from start to finished file
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+#include <QtGlobal>
+#include <vector>
+
+#include "capture_cli.h"
+#include "usb_device_info.h"
+
+class QTextStream;
+
+namespace ddd::gui {
+
+class CaptureController;
+
+// Start a capture as soon as a device is there, and then stop watching.
+//
+// The windowed half of --start-capture. There is no timeout and no exit code:
+// the window is up, so a device plugged in five minutes later still starts the
+// capture the command line asked for, and a user who would rather it did not
+// can simply not wait for it. The headless half is the runner below, which
+// needs both.
+//
+// The watch ends at the first device report that has something in it. An empty
+// report is what the monitor produces on every poll with nothing attached, so
+// a one-shot connection would be spent on the first of those and the capture
+// would never start.
+void StartCaptureWhenDeviceAppears(CaptureController* controller);
+
+// The two waits a headless run is bounded by. At namespace scope, as
+// StopCaptureOptions is, because a nested struct with defaults cannot be the
+// default argument of a constructor in the class that nests it.
+struct HeadlessCaptureOptions {
+  // How long to wait for a device before giving up. A script that runs this on
+  // a schedule wants to be told that nothing was plugged in, rather than to
+  // leave a process waiting until somebody notices it. Zero or less waits for
+  // as long as it takes.
+  int device_wait_milliseconds = 10000;
+
+  // How long to wait for the file after the capture has stopped. Not a guess at
+  // how long finalising takes — it is the bound that stops a run hanging
+  // forever if the pipeline never reports the file at all.
+  int finish_wait_milliseconds = 30000;
+};
+
+// Runs one capture from a command line and reports what happened through an
+// exit code.
+//
+// This is the whole of --headless: wait for a device, start, run until
+// something says to stop, and — the part that makes it worth having as a class
+// rather than as a few connections in main() — wait for the *file* rather than
+// for the capture. Stopping detaches the writer and says so immediately, but at
+// that moment the encoder has not closed the file, a capture whose naming asks
+// for its duration has not been renamed, and the sidecar has not been written.
+// A process that exited there would leave a script holding a path that is not
+// finished and may not even exist under that name.
+//
+// The two streams say different things and are meant for different readers. The
+// finished file's path goes to stdout, alone and unadorned, so that a script
+// can take what it reads without having to take it apart; everything meant for
+// a person watching goes to stderr. That is the same split --stop-capture uses.
+//
+// Nothing here quits the application. It reports an exit code and the caller
+// decides — which is what lets the whole lifecycle be tested against a fake
+// device with no process to end.
+class HeadlessCaptureRunner : public QObject {
+  Q_OBJECT
+
+ public:
+  HeadlessCaptureRunner(CaptureController* controller, QTextStream& out,
+                        QTextStream& error,
+                        const HeadlessCaptureOptions& options = {},
+                        QObject* parent = nullptr);
+
+  // Connect to the controller and start waiting for a device.
+  //
+  // Call this *before* CaptureController::Start(). The controller's first
+  // device report is the one that starts the capture, and a runner that was
+  // connected afterwards would miss it and wait for the next poll — or, if a
+  // device were already attached and then removed, for one that never comes.
+  void Begin();
+
+ public slots:
+  // Stop, and finish the file. What an interrupt means, and harmless both
+  // before a capture has started and after one has been stopped.
+  //
+  // A second call while the file is still being written is deliberately not a
+  // harder stop. The file is the point of the run, and the seconds an encoder
+  // takes to close one are the cheapest seconds in the whole capture.
+  void RequestStop();
+
+ signals:
+  // The run is over and this is what to exit with. Always emitted from the
+  // event loop, never from inside Begin() or from a controller call, so that a
+  // caller connecting this to QCoreApplication::quit() cannot have its quit
+  // arrive before exec() does.
+  void Finished(int exit_code);
+
+ private:
+  enum class State {
+    kIdle,
+    kWaitingForDevice,
+
+    // StartCapture() has been called and has not yet said what came of it.
+    kStarting,
+
+    kCapturing,
+
+    // The writer is detached and the file is being closed.
+    kFinishing,
+
+    kDone,
+  };
+
+  void OnDevicesChanged(const std::vector<capture::DeviceInfo>& devices);
+  void OnCapturingChanged(bool capturing, const QString& file_path);
+  void OnCaptureFinished(const QString& file_path, quint64 bytes);
+  void OnFailed(const QString& title, const QString& detail);
+
+  void StartCapture();
+
+  // Wait one turn of the event loop, then finish with whatever the exit code
+  // has become. The turn is what makes the exit code right: the controller
+  // emits CaptureFinished and then, in the same call, may emit Failed for the
+  // run that produced it — so a runner that exited on the first of those would
+  // report a failed capture as a success.
+  void ScheduleFinish();
+
+  void Finish(int exit_code);
+
+  // A line for whoever is watching. Flushed, because the reader is a terminal
+  // or a log being tailed and a line held in a buffer for the rest of a disc
+  // side is a line nobody sees.
+  void Say(const QString& line);
+
+  CaptureController* controller_ = nullptr;
+  QTextStream* out_ = nullptr;
+  QTextStream* error_ = nullptr;
+  HeadlessCaptureOptions options_;
+
+  QTimer device_timer_;
+  QTimer finish_timer_;
+
+  State state_ = State::kIdle;
+
+  // What the run will exit with unless something worse happens to it. Only ever
+  // moves away from success: a failure reported while the file is still being
+  // written has to survive the wait for it.
+  int exit_code_ = kExitSuccess;
+
+  bool finish_scheduled_ = false;
+};
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/main.cpp
+++ b/ddd-gui/src/gui/main.cpp
@@ -11,6 +11,7 @@
 
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QCoreApplication>
 #include <QLoggingCategory>
 #include <QString>
 #include <QTextStream>
@@ -23,18 +24,94 @@
 #include "analysis_cli.h"
 #include "application_logger.h"
 #include "auto_capture_controller.h"
+#include "capture_cli.h"
+#include "capture_control_server.h"
 #include "capture_controller.h"
+#include "capture_settings.h"
+#include "capture_stop_client.h"
 #include "console_attach.h"
+#include "headless_capture_runner.h"
 #include "log_options.h"
 #include "logger.h"
 #include "main_window.h"
 #include "platform_description.h"
 #include "player_controller.h"
 #include "qt_message_filter.h"
+#include "signal_watcher.h"
 #include "spdlog_logger.h"
 #include "theme_controller.h"
 #include "usb_device.h"
 #include "version.h"
+
+namespace {
+
+// A capture with no window around it: the whole of --headless.
+//
+// Everything it wires is tested elsewhere — the lifecycle in
+// HeadlessCaptureRunner, the socket in CaptureControlServer, the interrupt in
+// SignalWatcher — so what is left here is the wiring, and it is kept out of
+// main() so that the three modes read as three modes rather than as one long
+// function with branches in it.
+int RunHeadlessCapture(QCoreApplication& app, ddd::gui::ApplicationLogger& log,
+                       const ddd::gui::CaptureCliOptions& options,
+                       QTextStream& out, QTextStream& error) {
+  // A null backend is fatal here where the window survives it: a window with no
+  // device can still show settings and open a capture for reading, and a
+  // headless run has nothing left to do at all.
+  const std::unique_ptr<ddd::capture::IUsbDevice> usb_device =
+      ddd::capture::MakeUsbDevice(&log);
+
+  ddd::gui::CaptureController capture_controller(usb_device.get(), &log);
+
+  ddd::gui::CaptureSettings settings = capture_controller.settings();
+  ddd::gui::ApplyCliOverrides(settings, options);
+  capture_controller.ApplySessionSettings(settings);
+
+  // Before anything is started, and a hard failure rather than a warning. Two
+  // processes streaming from one device is not something either can do, and a
+  // headless capture that could not be reached over the socket would be a
+  // process a script had no way to stop — on Windows, where there is no
+  // interrupt to fall back on, no way at all.
+  ddd::gui::CaptureControlServer control_server(&capture_controller, &log);
+  QString listen_error;
+  if (!control_server.Listen(&listen_error)) {
+    error << listen_error << "\n";
+    error.flush();
+    return ddd::gui::kExitInstanceRunning;
+  }
+
+  ddd::gui::HeadlessCaptureRunner runner(&capture_controller, out, error);
+
+  int exit_code = ddd::gui::kExitSuccess;
+  QObject::connect(&runner, &ddd::gui::HeadlessCaptureRunner::Finished, &app,
+                   [&exit_code, &app](int code) {
+                     exit_code = code;
+                     app.quit();
+                   });
+
+  // Null on Windows, which has no POSIX signals. A Windows script stops a
+  // capture with --stop-capture, which is why the socket above is not optional.
+  ddd::gui::SignalWatcher* const watcher =
+      ddd::gui::SignalWatcher::Install(&app);
+  if (watcher != nullptr) {
+    QObject::connect(watcher, &ddd::gui::SignalWatcher::Interrupted, &runner,
+                     &ddd::gui::HeadlessCaptureRunner::RequestStop);
+  }
+
+  // The runner first, so that it is connected before the controller's first
+  // device report goes out — that report is the one that starts the capture.
+  runner.Begin();
+  capture_controller.Start();
+
+  QCoreApplication::exec();
+
+  // Stack destruction from here, exactly as the windowed path unwinds: the
+  // controller's destructor stops the monitor, the analysis worker and the
+  // pipeline in the order they have to be stopped in.
+  return exit_code;
+}
+
+}  // namespace
 
 int main(int argc, char* argv[]) {
   // First, before anything can write to a stream. On Windows this application
@@ -44,46 +121,75 @@ int main(int argc, char* argv[]) {
   // Linux or macOS.
   ddd::gui::AttachParentConsole();
 
-  QApplication::setHighDpiScaleFactorRoundingPolicy(
-      Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+  // Which application object to build, decided from the raw arguments because
+  // QCommandLineParser needs the application it is about to decide on. A
+  // headless capture and a --stop-capture client both want a QCoreApplication:
+  // a QApplication would demand a platform plugin neither has any use for,
+  // which on a machine with no display is the difference between running and
+  // refusing to start.
+  const bool core_only = ddd::gui::WantsCoreApplication(argc, argv);
 
-  // Qt's own Wayland plugin, not this application. Every popup — a menu, a
-  // submenu, a tooltip, a combo box — is a surface of its own, and when one
-  // goes away the compositor's text-input protocol sends a leave event for a
-  // surface the plugin has already forgotten, which it complains about:
-  //
-  //   qt.qpa.wayland.textinput: … Got leave event for surface 0x0 …
-  //
-  // Nothing is wrong and nothing can be done about it from here, so opening a
-  // menu would print a line of somebody else's diagnostics into a terminal a
-  // user is watching for this application's own messages. Silenced by category
-  // rather than by matching the text, so nothing else is hidden with it.
-  //
-  // Rules from QT_LOGGING_RULES are applied after these and win, so anybody
-  // debugging the plugin can still switch the category back on.
-  QLoggingCategory::setFilterRules(
-      QStringLiteral("qt.qpa.wayland.textinput=false"));
+  std::unique_ptr<QCoreApplication> app;
 
-  // The same plugin, and the same reasoning, for a message that carries no
-  // category to switch off. See qt_message_filter.h.
-  ddd::gui::InstallQtMessageFilter();
+  // The same object as app, when there is a window. Held separately because the
+  // theme controller takes a QApplication and the branch below is the only
+  // place that knows which of the two was built.
+  QApplication* gui_app = nullptr;
 
-  QApplication app(argc, argv);
+  if (core_only) {
+    app = std::make_unique<QCoreApplication>(argc, argv);
+  } else {
+    QApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+
+    // Qt's own Wayland plugin, not this application. Every popup — a menu, a
+    // submenu, a tooltip, a combo box — is a surface of its own, and when one
+    // goes away the compositor's text-input protocol sends a leave event for a
+    // surface the plugin has already forgotten, which it complains about:
+    //
+    //   qt.qpa.wayland.textinput: … Got leave event for surface 0x0 …
+    //
+    // Nothing is wrong and nothing can be done about it from here, so opening a
+    // menu would print a line of somebody else's diagnostics into a terminal a
+    // user is watching for this application's own messages. Silenced by
+    // category rather than by matching the text, so nothing else is hidden with
+    // it.
+    //
+    // Rules from QT_LOGGING_RULES are applied after these and win, so anybody
+    // debugging the plugin can still switch the category back on.
+    QLoggingCategory::setFilterRules(
+        QStringLiteral("qt.qpa.wayland.textinput=false"));
+
+    // The same plugin, and the same reasoning, for a message that carries no
+    // category to switch off. See qt_message_filter.h.
+    ddd::gui::InstallQtMessageFilter();
+
+    auto gui = std::make_unique<QApplication>(argc, argv);
+    gui_app = gui.get();
+    app = std::move(gui);
+  }
 
   // Set before anything constructs a QSettings: the identity decides which file
   // settings are read from and written to, and a QSettings built earlier would
   // quietly use a different one. The application name differs from the older
   // capture application's, so the two do not share a settings file.
-  QApplication::setOrganizationName(QStringLiteral("Domesday86"));
-  QApplication::setOrganizationDomain(QStringLiteral("domesday86.com"));
-  QApplication::setWindowIcon(ddd::gui::ApplicationIcon());
-  QApplication::setApplicationName(QStringLiteral("ddd-gui"));
+  //
+  // Unconditional, and not only for the window: a headless capture reads the
+  // same settings file, and one that read a different one would capture with
+  // settings nobody had ever chosen.
+  QCoreApplication::setOrganizationName(QStringLiteral("Domesday86"));
+  QCoreApplication::setOrganizationDomain(QStringLiteral("domesday86.com"));
+  QCoreApplication::setApplicationName(QStringLiteral("ddd-gui"));
+
+  if (!core_only) {
+    QApplication::setWindowIcon(ddd::gui::ApplicationIcon());
+  }
 
   // The commit this build was made from. The packaging workflows run --version
   // and reject an artefact that reports "unknown", which is what a build with
   // no commit to name says.
   const std::string commit(ddd::capture::Commit());
-  QApplication::setApplicationVersion(QString::fromStdString(commit));
+  QCoreApplication::setApplicationVersion(QString::fromStdString(commit));
 
   QCommandLineParser parser;
   parser.setApplicationDescription(
@@ -142,7 +248,10 @@ int main(int argc, char* argv[]) {
                      "formed and nothing about where it came from."));
   parser.addOption(development_key_option);
 
-  parser.process(app);
+  const ddd::gui::CaptureCliOptionSet capture_options =
+      ddd::gui::AddCaptureCliOptions(parser);
+
+  parser.process(*app);
 
   // Before the logger, the theme and the window, so that nothing about this
   // path depends on a display being available. On Windows the output goes to
@@ -156,7 +265,23 @@ int main(int argc, char* argv[]) {
                                          error);
   }
 
+  QTextStream out_stream(stdout);
   QTextStream error_stream(stderr);
+
+  const ddd::gui::CaptureCliParseResult capture_cli =
+      ddd::gui::ParseCaptureCliOptions(parser, capture_options);
+  if (!capture_cli.ok()) {
+    error_stream << capture_cli.error << "\n";
+    error_stream.flush();
+    return ddd::gui::kExitBadArguments;
+  }
+
+  // The client mode, and it is only a client: it opens no device, reads no
+  // settings and writes no log. Everything it does is one line down a socket to
+  // the application that is actually capturing.
+  if (capture_cli.options.stop_capture) {
+    return ddd::gui::RunStopCapture(out_stream, error_stream);
+  }
 
   ddd::capture::LogConfig log_config;
 
@@ -214,7 +339,21 @@ int main(int argc, char* argv[]) {
   ddd::gui::ApplicationLogger logger(&log_destinations);
   logger.SetMinimumLevel(log_config.level);
 
-  ddd::gui::ThemeController theme_controller(&app);
+  // With no window there is no Log panel, so nothing about the log can be said
+  // after one exists — it is said here, where a redirected console is the only
+  // place it can land.
+  if (capture_cli.options.headless) {
+    logger.Info("Application commit " + commit + ".");
+    logger.Info("Platform: " + ddd::gui::PlatformDescription().toStdString() +
+                ".");
+    for (const std::string& warning : log_destinations.warnings()) {
+      logger.Warning(warning);
+    }
+    return RunHeadlessCapture(*app, logger, capture_cli.options, out_stream,
+                              error_stream);
+  }
+
+  ddd::gui::ThemeController theme_controller(gui_app);
   theme_controller.Initialize();
 
   // A null backend is survivable rather than fatal: the window opens, says why
@@ -223,6 +362,17 @@ int main(int argc, char* argv[]) {
       ddd::capture::MakeUsbDevice(&logger);
 
   ddd::gui::CaptureController capture_controller(usb_device.get(), &logger);
+
+  // Before the window is built. CapturePanel reads the controller's settings in
+  // its constructor, so applying them here is what makes the panel open already
+  // showing what the command line asked for — and applied rather than set,
+  // because what a command line names belongs to this run and is not the user's
+  // new saved answer.
+  if (capture_cli.options.HasAttributeOverrides()) {
+    ddd::gui::CaptureSettings settings = capture_controller.settings();
+    ddd::gui::ApplyCliOverrides(settings, capture_cli.options);
+    capture_controller.ApplySessionSettings(settings);
+  }
 
   // Nothing is opened, enumerated or written to until the settings say player
   // control is on — see PlayerSettings::enabled, which is off until a user
@@ -293,10 +443,34 @@ int main(int argc, char* argv[]) {
                    " does not include a file.");
   }
 
+  // The window has one of these too, so that a capture started by hand and a
+  // capture started from a script are stopped the same way. Failure is fatal
+  // only when the command line asked for a capture: an ordinary second window
+  // is a reasonable thing to want — to read a capture, or to look at the
+  // settings — and refusing to open it because the first one holds the socket
+  // would be worse than losing --stop-capture for that instance.
+  ddd::gui::CaptureControlServer control_server(&capture_controller, &logger);
+  QString listen_error;
+  if (!control_server.Listen(&listen_error)) {
+    if (capture_cli.options.start_capture) {
+      error_stream << listen_error << "\n";
+      error_stream.flush();
+      return ddd::gui::kExitInstanceRunning;
+    }
+    logger.Warning(listen_error.toStdString() +
+                   " This window will not answer --stop-capture.");
+  }
+
   // Started after the window is up so that the first device report lands on a
   // window that already has panels to receive it.
   capture_controller.Start();
   player_controller.Start();
 
-  return QApplication::exec();
+  // After the controller is started, so that a device already attached is
+  // captured from at once rather than at the next poll.
+  if (capture_cli.options.start_capture) {
+    ddd::gui::StartCaptureWhenDeviceAppears(&capture_controller);
+  }
+
+  return QCoreApplication::exec();
 }

--- a/ddd-gui/src/gui/main.cpp
+++ b/ddd-gui/src/gui/main.cpp
@@ -89,8 +89,10 @@ int RunHeadlessCapture(QCoreApplication& app, ddd::gui::ApplicationLogger& log,
                      app.quit();
                    });
 
-  // Null on Windows, which has no POSIX signals. A Windows script stops a
-  // capture with --stop-capture, which is why the socket above is not optional.
+  // Ctrl+C and kill on Unix, a console control event on Windows. Null if the
+  // platform would not take the handler, which is not a reason to refuse to
+  // capture: --stop-capture works whatever this returns, which is why the
+  // socket above is not optional and this is.
   ddd::gui::SignalWatcher* const watcher =
       ddd::gui::SignalWatcher::Install(&app);
   if (watcher != nullptr) {

--- a/ddd-gui/src/gui/main_window.cpp
+++ b/ddd-gui/src/gui/main_window.cpp
@@ -236,8 +236,12 @@ MainWindow::MainWindow(ThemeController* theme_controller,
     connect(capture_controller_, &CaptureController::CaptureRenamed, this,
             [this](const QString& requested, const QString& written) {
               const QString message =
-                  tr("\u201c%1\u201d was already taken — capturing to "
-                     "\u201c%2\u201d instead.")
+                  // Worded for both of the moments this can arrive at: the
+                  // name is resolved before the file is opened, and resolved
+                  // again if the length added to it at the end lands on a
+                  // name that is taken too.
+                  tr("\u201c%1\u201d was already taken — this capture "
+                     "is \u201c%2\u201d.")
                       .arg(requested, written);
               statusBar()->showMessage(message);
               if (logger_ != nullptr) {

--- a/ddd-gui/src/gui/signal_watcher.cpp
+++ b/ddd-gui/src/gui/signal_watcher.cpp
@@ -1,0 +1,178 @@
+/************************************************************************
+
+    signal_watcher.cpp
+
+    Ctrl+C and kill, delivered somewhere a capture can be finished properly
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include "signal_watcher.h"
+
+#include <QSocketNotifier>
+
+#ifndef Q_OS_WIN
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <csignal>
+#endif
+
+namespace ddd::gui {
+namespace {
+
+#ifndef Q_OS_WIN
+
+// The write end of the socketpair, where the handler can reach it.
+//
+// A file-scope variable rather than anything belonging to the object, because
+// the handler runs with no context of its own: it is handed a signal number and
+// nothing else, and sig_atomic_t is the only kind of variable the standard says
+// it may read.
+volatile std::sig_atomic_t g_write_descriptor = -1;
+
+// The one watcher, so that a second Install() can refuse rather than quietly
+// take the descriptor above away from the first.
+SignalWatcher* g_watcher = nullptr;
+
+extern "C" void HandleInterrupt(int /*number*/) {
+  const int descriptor = g_write_descriptor;
+  if (descriptor < 0) {
+    return;
+  }
+
+  // errno belongs to whoever was interrupted. A handler that returns having
+  // changed it turns an unrelated call's success into a spurious failure — and
+  // this one runs in the middle of a capture, where the calls being interrupted
+  // are the ones writing the file.
+  const int saved_errno = errno;
+
+  const char byte = 1;
+  const ssize_t written = ::write(descriptor, &byte, 1);
+
+  // Nothing can be done about a write that failed from here, and there is
+  // nowhere to report it to: the descriptor is a socketpair that only fills if
+  // the notifier has stopped reading, which is a stopped event loop, which is a
+  // process that is already leaving.
+  static_cast<void>(written);
+
+  errno = saved_errno;
+}
+
+bool InstallHandler(int number) {
+  struct sigaction action = {};
+  action.sa_handler = HandleInterrupt;
+  sigemptyset(&action.sa_mask);
+
+  // SA_RESTART so that a read or a write the interrupt lands in the middle of
+  // resumes instead of failing with EINTR. The point of this class is that an
+  // interrupt does not disturb a capture until the event loop chooses to act on
+  // it, and a transfer that failed on the way in would disturb it.
+  action.sa_flags = SA_RESTART;
+
+  return ::sigaction(number, &action, nullptr) == 0;
+}
+
+void RestoreHandler(int number) {
+  struct sigaction action = {};
+  action.sa_handler = SIG_DFL;
+  sigemptyset(&action.sa_mask);
+  static_cast<void>(::sigaction(number, &action, nullptr));
+}
+
+#endif  // !Q_OS_WIN
+
+}  // namespace
+
+SignalWatcher::SignalWatcher(int read_descriptor, int write_descriptor,
+                             QObject* parent)
+    : QObject(parent),
+      read_descriptor_(read_descriptor),
+      write_descriptor_(write_descriptor),
+      notifier_(
+          new QSocketNotifier(read_descriptor, QSocketNotifier::Read, this)) {
+  connect(notifier_, &QSocketNotifier::activated, this,
+          &SignalWatcher::OnActivated);
+}
+
+SignalWatcher::~SignalWatcher() {
+#ifndef Q_OS_WIN
+  // The handlers first: after this nothing can write to the descriptor being
+  // closed below, which is the only ordering that matters here.
+  RestoreHandler(SIGINT);
+  RestoreHandler(SIGTERM);
+  g_write_descriptor = -1;
+  g_watcher = nullptr;
+
+  delete notifier_;
+  notifier_ = nullptr;
+
+  if (read_descriptor_ >= 0) {
+    ::close(read_descriptor_);
+  }
+  if (write_descriptor_ >= 0) {
+    ::close(write_descriptor_);
+  }
+#endif
+}
+
+SignalWatcher* SignalWatcher::Install(QObject* parent) {
+#ifdef Q_OS_WIN
+  // No POSIX signals, and a GUI-subsystem executable has no console to be
+  // interrupted from in the first place. A Windows script stops a capture by
+  // running the application again with --stop-capture, which works everywhere
+  // and is what the documentation tells everyone to use.
+  Q_UNUSED(parent);
+  return nullptr;
+#else
+  if (g_watcher != nullptr) {
+    return nullptr;
+  }
+
+  int descriptors[2] = {-1, -1};
+  if (::socketpair(AF_UNIX, SOCK_STREAM, 0, descriptors) != 0) {
+    return nullptr;
+  }
+
+  g_write_descriptor = descriptors[1];
+
+  if (!InstallHandler(SIGINT) || !InstallHandler(SIGTERM)) {
+    RestoreHandler(SIGINT);
+    RestoreHandler(SIGTERM);
+    g_write_descriptor = -1;
+    ::close(descriptors[0]);
+    ::close(descriptors[1]);
+    return nullptr;
+  }
+
+  auto* watcher = new SignalWatcher(descriptors[0], descriptors[1], parent);
+  g_watcher = watcher;
+  return watcher;
+#endif
+}
+
+bool SignalWatcher::installed() {
+#ifdef Q_OS_WIN
+  return false;
+#else
+  return g_watcher != nullptr;
+#endif
+}
+
+void SignalWatcher::OnActivated() {
+#ifndef Q_OS_WIN
+  // Drained rather than read one byte at a time, so that several interrupts
+  // arriving together leave nothing behind to fire the notifier again for an
+  // instruction already acted on.
+  char buffer[16] = {};
+  const ssize_t read_bytes = ::read(read_descriptor_, buffer, sizeof(buffer));
+  static_cast<void>(read_bytes);
+#endif
+
+  emit Interrupted();
+}
+
+}  // namespace ddd::gui

--- a/ddd-gui/src/gui/signal_watcher.cpp
+++ b/ddd-gui/src/gui/signal_watcher.cpp
@@ -11,9 +11,14 @@
 
 #include "signal_watcher.h"
 
+#include <QMetaObject>
 #include <QSocketNotifier>
 
-#ifndef Q_OS_WIN
+#ifdef Q_OS_WIN
+#include <windows.h>
+
+#include <mutex>
+#else
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -24,7 +29,45 @@
 namespace ddd::gui {
 namespace {
 
-#ifndef Q_OS_WIN
+#ifdef Q_OS_WIN
+
+// The watcher, and the lock the console's own thread takes to reach it.
+//
+// A console control handler does not run on the thread that installed it:
+// Windows makes one for the occasion, and it can arrive at any moment —
+// including while this object is being destroyed on the main thread.
+std::mutex g_watcher_mutex;
+SignalWatcher* g_watcher = nullptr;
+
+BOOL WINAPI HandleConsoleControl(DWORD type) {
+  // Ctrl+C, Ctrl+Break, and the break a script sends with
+  // GenerateConsoleCtrlEvent. Everything else is left to the default handler,
+  // which ends the process: closing the console window, logging off and
+  // shutting down all give a process a few seconds to be finished in and then
+  // end it whatever it says, so answering them would be a promise this cannot
+  // keep. Those are the cases --stop-capture is for.
+  if (type != CTRL_C_EVENT && type != CTRL_BREAK_EVENT) {
+    return FALSE;
+  }
+
+  const std::lock_guard<std::mutex> lock(g_watcher_mutex);
+  if (g_watcher == nullptr) {
+    return FALSE;
+  }
+
+  // Posted rather than called. This is another thread, and everything the
+  // interrupt leads to — stopping a capture, closing an encoder, writing a
+  // sidecar — belongs to the one running the event loop. A queued call is
+  // taken off the queue again if the watcher is destroyed first, so there is
+  // nothing here that can outlive what it points at.
+  QMetaObject::invokeMethod(g_watcher, "Deliver", Qt::QueuedConnection);
+
+  // Handled, which is what keeps Windows from ending the process before the
+  // file has been finished.
+  return TRUE;
+}
+
+#else
 
 // The write end of the socketpair, where the handler can reach it.
 //
@@ -91,15 +134,29 @@ SignalWatcher::SignalWatcher(int read_descriptor, int write_descriptor,
                              QObject* parent)
     : QObject(parent),
       read_descriptor_(read_descriptor),
-      write_descriptor_(write_descriptor),
-      notifier_(
-          new QSocketNotifier(read_descriptor, QSocketNotifier::Read, this)) {
+      write_descriptor_(write_descriptor) {
+  // No descriptor to watch on Windows, where the handler posts for itself.
+  if (read_descriptor_ < 0) {
+    return;
+  }
+
+  notifier_ =
+      new QSocketNotifier(read_descriptor_, QSocketNotifier::Read, this);
   connect(notifier_, &QSocketNotifier::activated, this,
           &SignalWatcher::OnActivated);
 }
 
 SignalWatcher::~SignalWatcher() {
-#ifndef Q_OS_WIN
+#ifdef Q_OS_WIN
+  // Forgotten first, then unregistered. A handler already running holds the
+  // lock and will find nothing to post to; one that arrives afterwards finds
+  // no handler at all and the process ends as it normally would.
+  {
+    const std::lock_guard<std::mutex> lock(g_watcher_mutex);
+    g_watcher = nullptr;
+  }
+  SetConsoleCtrlHandler(&HandleConsoleControl, FALSE);
+#else
   // The handlers first: after this nothing can write to the descriptor being
   // closed below, which is the only ordering that matters here.
   RestoreHandler(SIGINT);
@@ -121,12 +178,27 @@ SignalWatcher::~SignalWatcher() {
 
 SignalWatcher* SignalWatcher::Install(QObject* parent) {
 #ifdef Q_OS_WIN
-  // No POSIX signals, and a GUI-subsystem executable has no console to be
-  // interrupted from in the first place. A Windows script stops a capture by
-  // running the application again with --stop-capture, which works everywhere
-  // and is what the documentation tells everyone to use.
-  Q_UNUSED(parent);
-  return nullptr;
+  {
+    const std::lock_guard<std::mutex> lock(g_watcher_mutex);
+    if (g_watcher != nullptr) {
+      return nullptr;
+    }
+  }
+
+  if (SetConsoleCtrlHandler(&HandleConsoleControl, TRUE) == 0) {
+    return nullptr;
+  }
+
+  // Registering with no console attached is not a failure and is not worth
+  // refusing over: a headless run reaches its parent's console through
+  // AttachConsole, and one started from a shortcut has none to be interrupted
+  // from, so the handler is simply never called.
+  auto* watcher = new SignalWatcher(-1, -1, parent);
+  {
+    const std::lock_guard<std::mutex> lock(g_watcher_mutex);
+    g_watcher = watcher;
+  }
+  return watcher;
 #else
   if (g_watcher != nullptr) {
     return nullptr;
@@ -156,10 +228,9 @@ SignalWatcher* SignalWatcher::Install(QObject* parent) {
 
 bool SignalWatcher::installed() {
 #ifdef Q_OS_WIN
-  return false;
-#else
-  return g_watcher != nullptr;
+  const std::lock_guard<std::mutex> lock(g_watcher_mutex);
 #endif
+  return g_watcher != nullptr;
 }
 
 void SignalWatcher::OnActivated() {
@@ -172,7 +243,9 @@ void SignalWatcher::OnActivated() {
   static_cast<void>(read_bytes);
 #endif
 
-  emit Interrupted();
+  Deliver();
 }
+
+void SignalWatcher::Deliver() { emit Interrupted(); }
 
 }  // namespace ddd::gui

--- a/ddd-gui/src/gui/signal_watcher.h
+++ b/ddd-gui/src/gui/signal_watcher.h
@@ -17,23 +17,33 @@ class QSocketNotifier;
 
 namespace ddd::gui {
 
-// Turns SIGINT and SIGTERM into a signal on the event loop.
+// Turns an interrupt into a signal on the event loop.
 //
-// A headless capture is stopped by the script that started it, and the two ways
-// a script does that are Ctrl+C and kill. Neither can be handled where it
-// arrives: a signal handler may call almost nothing — not new, not a QObject's
-// method, not a FLAC encoder's finaliser — and the default disposition of both
-// is to end the process immediately, which leaves the last block unwritten and
-// the sidecar never written at all.
+// A headless capture is stopped by the script that started it, and every way a
+// script does that ends the process where it stands unless something catches
+// it — leaving the last block unwritten and the sidecar never written at all.
+// What arrives differs by platform; what has to happen does not.
 //
-// So the handler does the one thing it is allowed to do: write a byte down a
+// **On Unix** it is SIGINT and SIGTERM, and a signal handler may call almost
+// nothing: not new, not a QObject's method, not a FLAC encoder's finaliser. So
+// the handler does the one thing it is allowed to do — write a byte down a
 // socketpair. The read end is watched by a QSocketNotifier, so the interrupt
 // arrives as an ordinary queued event on the event loop, in a context where
 // stopping the capture and waiting for the file to close is just code.
 //
-// One at a time. The handler needs a descriptor it can see without touching
-// anything of the object's, so it is held in a file-scope variable, and a
-// second watcher would overwrite the first one's. Install() refuses instead.
+// **On Windows** it is a console control event: Ctrl+C, Ctrl+Break, or the
+// CTRL_BREAK_EVENT a script sends with GenerateConsoleCtrlEvent. There are no
+// POSIX signals to catch, and until this existed the default handler ended the
+// process — which a headless run reaches through AttachConsole, so pressing
+// Ctrl+C at the prompt that started a capture truncated its file. The handler
+// runs on a thread Windows makes for it rather than in the middle of the
+// program, so it may allocate and it may post; posting is what it does, and
+// the interrupt arrives on the event loop exactly as it does on Unix.
+//
+// One at a time, on both. The Unix handler needs a descriptor it can see
+// without touching anything of the object's, so it is held in a file-scope
+// variable, and a second watcher would overwrite the first one's. Install()
+// refuses instead.
 class SignalWatcher : public QObject {
   Q_OBJECT
 
@@ -45,9 +55,11 @@ class SignalWatcher : public QObject {
   SignalWatcher(SignalWatcher&&) = delete;
   SignalWatcher& operator=(SignalWatcher&&) = delete;
 
-  // Install the handlers. Returns the watcher, or nullptr when there is nothing
-  // to install: on Windows, which has no POSIX signals — a Windows script stops
-  // a capture with --stop-capture instead — and when a watcher already exists.
+  // Install the handlers. Returns the watcher, or nullptr when there is
+  // nothing to install: when one already exists, or when the platform refused
+  // to take the handler. A caller carries on without one — a capture can still
+  // be stopped with --stop-capture, and on Windows that remains the way a
+  // script running outside the capture's own console stops it.
   //
   // Ownership follows the parent, as it does for any QObject. Pass one, or
   // delete it yourself; destroying it puts the previous disposition back, so a
@@ -67,11 +79,19 @@ class SignalWatcher : public QObject {
   // user who thinks nothing happened rather than a different instruction.
   void Interrupted();
 
+ private slots:
+  // The interrupt, arriving on the event loop. A slot rather than a plain
+  // method because the Windows handler reaches it by name from the thread
+  // Windows called it on, which is the whole of how it crosses over.
+  void Deliver();
+
  private:
   SignalWatcher(int read_descriptor, int write_descriptor, QObject* parent);
 
   void OnActivated();
 
+  // Both -1 on Windows, where there is no socketpair and no notifier: a
+  // console handler can post for itself.
   int read_descriptor_ = -1;
   int write_descriptor_ = -1;
   QSocketNotifier* notifier_ = nullptr;

--- a/ddd-gui/src/gui/signal_watcher.h
+++ b/ddd-gui/src/gui/signal_watcher.h
@@ -1,0 +1,80 @@
+/************************************************************************
+
+    signal_watcher.h
+
+    Ctrl+C and kill, delivered somewhere a capture can be finished properly
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+class QSocketNotifier;
+
+namespace ddd::gui {
+
+// Turns SIGINT and SIGTERM into a signal on the event loop.
+//
+// A headless capture is stopped by the script that started it, and the two ways
+// a script does that are Ctrl+C and kill. Neither can be handled where it
+// arrives: a signal handler may call almost nothing — not new, not a QObject's
+// method, not a FLAC encoder's finaliser — and the default disposition of both
+// is to end the process immediately, which leaves the last block unwritten and
+// the sidecar never written at all.
+//
+// So the handler does the one thing it is allowed to do: write a byte down a
+// socketpair. The read end is watched by a QSocketNotifier, so the interrupt
+// arrives as an ordinary queued event on the event loop, in a context where
+// stopping the capture and waiting for the file to close is just code.
+//
+// One at a time. The handler needs a descriptor it can see without touching
+// anything of the object's, so it is held in a file-scope variable, and a
+// second watcher would overwrite the first one's. Install() refuses instead.
+class SignalWatcher : public QObject {
+  Q_OBJECT
+
+ public:
+  ~SignalWatcher() override;
+
+  SignalWatcher(const SignalWatcher&) = delete;
+  SignalWatcher& operator=(const SignalWatcher&) = delete;
+  SignalWatcher(SignalWatcher&&) = delete;
+  SignalWatcher& operator=(SignalWatcher&&) = delete;
+
+  // Install the handlers. Returns the watcher, or nullptr when there is nothing
+  // to install: on Windows, which has no POSIX signals — a Windows script stops
+  // a capture with --stop-capture instead — and when a watcher already exists.
+  //
+  // Ownership follows the parent, as it does for any QObject. Pass one, or
+  // delete it yourself; destroying it puts the previous disposition back, so a
+  // second interrupt after that ends the process as it normally would.
+  static SignalWatcher* Install(QObject* parent = nullptr);
+
+  // Whether a watcher is installed. Nothing in the application asks — the tests
+  // do, because "it was cleaned up" is otherwise unobservable.
+  static bool installed();
+
+ signals:
+  // An interrupt arrived. Emitted on the thread the watcher was made on.
+  //
+  // Once per arrival rather than once per signal: two interrupts close enough
+  // together are one byte as far as the notifier is concerned. That is the
+  // right way round — the first one already means "stop", and the second is a
+  // user who thinks nothing happened rather than a different instruction.
+  void Interrupted();
+
+ private:
+  SignalWatcher(int read_descriptor, int write_descriptor, QObject* parent);
+
+  void OnActivated();
+
+  int read_descriptor_ = -1;
+  int write_descriptor_ = -1;
+  QSocketNotifier* notifier_ = nullptr;
+};
+
+}  // namespace ddd::gui

--- a/ddd-gui/tests/CMakeLists.txt
+++ b/ddd-gui/tests/CMakeLists.txt
@@ -262,7 +262,9 @@ ddd_add_test(ddd_gui_tests "unit"
     gui/unit/test_log_message_model.cpp
     gui/unit/test_application_logger.cpp
     gui/unit/test_capture_settings.cpp
+    gui/unit/test_capture_cli.cpp
     gui/unit/test_capture_controller.cpp
+    gui/unit/test_signal_watcher.cpp
     gui/unit/test_capture_to_disk.cpp
     gui/unit/test_capture_faults.cpp
     gui/unit/test_capture_failure_presenter.cpp

--- a/ddd-gui/tests/CMakeLists.txt
+++ b/ddd-gui/tests/CMakeLists.txt
@@ -266,6 +266,7 @@ ddd_add_test(ddd_gui_tests "unit"
     gui/unit/test_capture_control_server.cpp
     gui/unit/test_capture_controller.cpp
     gui/unit/test_signal_watcher.cpp
+    gui/unit/test_headless_capture_runner.cpp
     gui/unit/test_capture_to_disk.cpp
     gui/unit/test_capture_faults.cpp
     gui/unit/test_capture_failure_presenter.cpp

--- a/ddd-gui/tests/CMakeLists.txt
+++ b/ddd-gui/tests/CMakeLists.txt
@@ -263,6 +263,7 @@ ddd_add_test(ddd_gui_tests "unit"
     gui/unit/test_application_logger.cpp
     gui/unit/test_capture_settings.cpp
     gui/unit/test_capture_cli.cpp
+    gui/unit/test_capture_control_server.cpp
     gui/unit/test_capture_controller.cpp
     gui/unit/test_signal_watcher.cpp
     gui/unit/test_capture_to_disk.cpp

--- a/ddd-gui/tests/gui/unit/test_capture_cli.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_cli.cpp
@@ -1,0 +1,392 @@
+/************************************************************************
+
+    test_capture_cli.cpp
+
+    T1 tests for the capture options the command line accepts
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <QCommandLineParser>
+#include <QString>
+#include <QStringList>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "capture_cli.h"
+#include "capture_format.h"
+#include "capture_settings.h"
+
+namespace ddd::gui {
+namespace {
+
+// What a run of the command line produced: whether Qt's parser accepted the
+// tokens at all, and then what this application made of them. The two are
+// separate failures — an unknown switch is Qt's complaint, a switch that cannot
+// mean what it says is this application's — and a test that conflated them
+// would pass when the wrong half worked.
+struct Parsed {
+  bool accepted = false;
+  CaptureCliOptions options;
+  QString error;
+
+  bool ok() const { return accepted && error.isEmpty(); }
+};
+
+Parsed Parse(const QStringList& arguments) {
+  QCommandLineParser parser;
+  const CaptureCliOptionSet set = AddCaptureCliOptions(parser);
+
+  QStringList line;
+  line.append(QStringLiteral("ddd-gui"));
+  line.append(arguments);
+
+  Parsed parsed;
+  parsed.accepted = parser.parse(line);
+  if (!parsed.accepted) {
+    parsed.error = parser.errorText();
+    return parsed;
+  }
+
+  const CaptureCliParseResult result = ParseCaptureCliOptions(parser, set);
+  parsed.options = result.options;
+  parsed.error = result.error;
+  return parsed;
+}
+
+// WantsCoreApplication() reads the raw arguments, so a test has to hand it the
+// same thing main() gets rather than a QStringList.
+bool WantsCore(const std::vector<std::string>& arguments) {
+  std::vector<std::string> storage;
+  storage.emplace_back("ddd-gui");
+  storage.insert(storage.end(), arguments.begin(), arguments.end());
+
+  std::vector<char*> line;
+  line.reserve(storage.size());
+  for (std::string& token : storage) {
+    line.push_back(token.data());
+  }
+
+  return WantsCoreApplication(static_cast<int>(line.size()), line.data());
+}
+
+// --- What the switches mean ----------------------------------------------
+
+TEST(CaptureCliTest, ACommandLineWithNoneOfThemAsksForNothing) {
+  const Parsed parsed = Parse({});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_FALSE(parsed.options.start_capture);
+  EXPECT_FALSE(parsed.options.stop_capture);
+  EXPECT_FALSE(parsed.options.headless);
+  EXPECT_FALSE(parsed.options.HasAttributeOverrides());
+}
+
+// The window still opens. This is the case the feature was asked for: a script
+// starts the capture at the same moment it starts recording audio somewhere
+// else, and the user watches both from the application they already had open.
+TEST(CaptureCliTest, StartCaptureOnItsOwnKeepsTheWindow) {
+  const Parsed parsed = Parse({QStringLiteral("--start-capture")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_TRUE(parsed.options.start_capture);
+  EXPECT_FALSE(parsed.options.headless);
+}
+
+TEST(CaptureCliTest, HeadlessWithoutStartCaptureIsRefused) {
+  const Parsed parsed = Parse({QStringLiteral("--headless")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("--start-capture")))
+      << parsed.error.toStdString();
+}
+
+TEST(CaptureCliTest, HeadlessWithStartCaptureIsTheScriptedRun) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--headless"), QStringLiteral("--start-capture")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_TRUE(parsed.options.headless);
+  EXPECT_TRUE(parsed.options.start_capture);
+}
+
+// --stop-capture is a message to a process that was set up long ago. Anything
+// beside it is an instruction with nowhere to go.
+TEST(CaptureCliTest, StopCaptureBesideStartCaptureIsRefused) {
+  const Parsed parsed = Parse(
+      {QStringLiteral("--stop-capture"), QStringLiteral("--start-capture")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_FALSE(parsed.error.isEmpty());
+}
+
+TEST(CaptureCliTest, StopCaptureBesideAnAttributeIsRefused) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--stop-capture"), QStringLiteral("--capture-name"),
+             QStringLiteral("disc-1")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_FALSE(parsed.error.isEmpty());
+}
+
+// Attributes with no start command are not a mistake: they are "set this up for
+// me and I will press the button myself", and they populate the window.
+TEST(CaptureCliTest, AttributesWithNoStartCommandAreForTheWindow) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--capture-name"), QStringLiteral("disc-1"),
+             QStringLiteral("--duration-limit"), QStringLiteral("90")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_FALSE(parsed.options.start_capture);
+  EXPECT_TRUE(parsed.options.HasAttributeOverrides());
+}
+
+// --- Values ----------------------------------------------------------------
+
+TEST(CaptureCliTest, TheTapeRateIsTheDecimatedOne) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--sample-rate"), QStringLiteral("20")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_EQ(parsed.options.decimation_factor,
+            std::optional<int>(capture::kTapeDecimationFactor));
+}
+
+TEST(CaptureCliTest, TheDiscRateIsNoDecimationAtAll) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--sample-rate"), QStringLiteral("40")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_EQ(parsed.options.decimation_factor,
+            std::optional<int>(capture::kUndecimatedFactor));
+}
+
+// The message names the rates that would have worked. A script author reading
+// it in a log has no application in front of them to go and look at.
+TEST(CaptureCliTest, ARateTheDeviceCannotCaptureAtIsRefused) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--sample-rate"), QStringLiteral("30")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("40")))
+      << parsed.error.toStdString();
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("20")))
+      << parsed.error.toStdString();
+}
+
+TEST(CaptureCliTest, ARateThatIsNotANumberIsRefused) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--sample-rate"), QStringLiteral("fast")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_FALSE(parsed.error.isEmpty());
+}
+
+TEST(CaptureCliTest, ADurationLimitIsTakenInSeconds) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--duration-limit"), QStringLiteral("3600")});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_EQ(parsed.options.duration_limit_seconds, std::optional<int>(3600));
+}
+
+// Zero is how the settings spell "no limit", and it is refused here rather than
+// read as one: a script that computed a limit of zero has a bug, and a capture
+// that then ran until the disk filled would be a long way from where the bug
+// is. Leaving the switch out is how a script asks for no limit.
+TEST(CaptureCliTest, ADurationLimitOfZeroIsRefused) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--duration-limit"), QStringLiteral("0")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("leave it out")))
+      << parsed.error.toStdString();
+}
+
+TEST(CaptureCliTest, ADurationLimitBeyondADayIsRefused) {
+  const Parsed parsed = Parse(
+      {QStringLiteral("--duration-limit"),
+       QString::number(CaptureSettings::kMaximumDurationLimitSeconds + 1)});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_FALSE(parsed.error.isEmpty());
+}
+
+TEST(CaptureCliTest, BothOutputFormatsAreAccepted) {
+  const Parsed flac =
+      Parse({QStringLiteral("--output-format"), QStringLiteral("flac")});
+  ASSERT_TRUE(flac.ok()) << flac.error.toStdString();
+  EXPECT_EQ(flac.options.output_format,
+            std::optional<capture::CaptureOutputFormat>(
+                capture::CaptureOutputFormat::kFlac));
+
+  const Parsed raw =
+      Parse({QStringLiteral("--output-format"), QStringLiteral("s16")});
+  ASSERT_TRUE(raw.ok()) << raw.error.toStdString();
+  EXPECT_EQ(raw.options.output_format,
+            std::optional<capture::CaptureOutputFormat>(
+                capture::CaptureOutputFormat::kSigned16Bit));
+}
+
+// The settings loader reads anything it does not recognise as FLAC, because a
+// settings file naming a format this build does not have should still produce a
+// working capture. A command line is the opposite case: it was typed for this
+// run, and a script that asked for raw samples and silently got FLAC would find
+// out when something downstream failed to read the file.
+TEST(CaptureCliTest, AFormatThisBuildDoesNotWriteIsRefusedRatherThanIgnored) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--output-format"), QStringLiteral("ldf")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("ldf")))
+      << parsed.error.toStdString();
+}
+
+TEST(CaptureCliTest, AnEmptyCaptureNameIsRefused) {
+  const Parsed parsed = Parse({QStringLiteral("--capture-name"), QString()});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_FALSE(parsed.error.isEmpty());
+}
+
+// The window's name field would take this and fail when the file was opened,
+// which for a scripted run means a failure minutes later and nothing captured.
+TEST(CaptureCliTest, ACaptureNameHoldingAPathIsRefused) {
+  const Parsed parsed = Parse(
+      {QStringLiteral("--capture-name"), QStringLiteral("disc-1/side-a")});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("--capture-directory")))
+      << parsed.error.toStdString();
+}
+
+// --- The capture folder ----------------------------------------------------
+
+class CaptureCliDirectoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const ::testing::TestInfo* const info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    directory_ = std::filesystem::temp_directory_path() /
+                 (std::string("ddd-capture-cli-") + info->name());
+    std::filesystem::remove_all(directory_);
+    std::filesystem::create_directories(directory_);
+  }
+
+  void TearDown() override { std::filesystem::remove_all(directory_); }
+
+  QString PathOf(const std::filesystem::path& path) const {
+    return QString::fromStdString(path.string());
+  }
+
+  std::filesystem::path directory_;
+};
+
+TEST_F(CaptureCliDirectoryTest, AFolderThatIsThereIsAccepted) {
+  const Parsed parsed =
+      Parse({QStringLiteral("--capture-directory"), PathOf(directory_)});
+
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+  EXPECT_EQ(parsed.options.capture_directory,
+            std::optional<QString>(PathOf(directory_)));
+}
+
+// A capture started from the window makes its folder, so one that is not there
+// yet is an ordinary instruction rather than a mistake: a script naming a
+// folder per disc should not have to create it first.
+TEST_F(CaptureCliDirectoryTest, AFolderThatIsNotThereYetIsAccepted) {
+  const Parsed parsed = Parse(
+      {QStringLiteral("--capture-directory"), PathOf(directory_ / "disc-042")});
+
+  EXPECT_TRUE(parsed.ok()) << parsed.error.toStdString();
+}
+
+// A file where a folder was named is the one case nothing downstream can
+// recover from, so it is the one case refused here.
+TEST_F(CaptureCliDirectoryTest, AFileWhereAFolderWasNamedIsRefused) {
+  const std::filesystem::path file = directory_ / "not-a-folder";
+  {
+    std::ofstream stream(file);
+    stream << "occupied";
+  }
+
+  const Parsed parsed =
+      Parse({QStringLiteral("--capture-directory"), PathOf(file)});
+
+  EXPECT_TRUE(parsed.accepted);
+  EXPECT_TRUE(parsed.error.contains(QStringLiteral("not a folder")))
+      << parsed.error.toStdString();
+}
+
+// --- Laying them over the settings -----------------------------------------
+
+TEST(CaptureCliTest, OnlyWhatWasNamedChanges) {
+  CaptureSettings settings;
+  settings.capture_directory = QStringLiteral("/captures");
+  settings.capture_name = QStringLiteral("saved-name");
+  settings.decimation_factor = capture::kUndecimatedFactor;
+  settings.duration_limit_seconds = 0;
+  settings.output_format = capture::CaptureOutputFormat::kFlac;
+  settings.compression_level = 3;
+
+  CaptureCliOptions options;
+  options.capture_name = QStringLiteral("disc-1");
+  options.duration_limit_seconds = 120;
+
+  ApplyCliOverrides(settings, options);
+
+  EXPECT_EQ(settings.capture_name, QStringLiteral("disc-1"));
+  EXPECT_EQ(settings.duration_limit_seconds, 120);
+
+  // Everything the command line said nothing about is the user's saved answer,
+  // untouched.
+  EXPECT_EQ(settings.capture_directory, QStringLiteral("/captures"));
+  EXPECT_EQ(settings.decimation_factor, capture::kUndecimatedFactor);
+  EXPECT_EQ(settings.output_format, capture::CaptureOutputFormat::kFlac);
+  EXPECT_EQ(settings.compression_level, 3);
+}
+
+TEST(CaptureCliTest, ACommandLineThatNamedNothingChangesNothing) {
+  const CaptureSettings saved;
+  CaptureSettings settings = saved;
+
+  ApplyCliOverrides(settings, CaptureCliOptions{});
+
+  EXPECT_EQ(settings, saved);
+}
+
+// --- Which application object to build -------------------------------------
+
+// Read before any application object exists, so that a machine with no display
+// can run a scripted capture at all.
+TEST(CaptureCliTest, TheScriptedModesNeedNoDisplay) {
+  EXPECT_TRUE(WantsCore({"--headless", "--start-capture"}));
+  EXPECT_TRUE(WantsCore({"--stop-capture"}));
+}
+
+TEST(CaptureCliTest, TheWindowedModesDo) {
+  EXPECT_FALSE(WantsCore({}));
+  EXPECT_FALSE(WantsCore({"--start-capture"}));
+  EXPECT_FALSE(WantsCore({"--capture-name", "disc-1"}));
+}
+
+// Qt's parser takes a long name with one dash as well as two, so this has to
+// recognise both or a spelling the application accepts would build the wrong
+// application object and then fail to start.
+TEST(CaptureCliTest, OneDashIsTheSameSwitch) {
+  EXPECT_TRUE(WantsCore({"-headless", "-start-capture"}));
+  EXPECT_TRUE(WantsCore({"-stop-capture"}));
+}
+
+TEST(CaptureCliTest, NothingAfterABareDoubleDashIsASwitch) {
+  EXPECT_FALSE(WantsCore({"--", "--headless"}));
+}
+
+}  // namespace
+}  // namespace ddd::gui

--- a/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
@@ -1,0 +1,484 @@
+/************************************************************************
+
+    test_capture_control_server.cpp
+
+    T1 tests for the socket a script stops a capture through
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QFile>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QSettings>
+#include <QString>
+#include <QTextStream>
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "capture_cli.h"
+#include "capture_control_server.h"
+#include "capture_controller.h"
+#include "capture_format.h"
+#include "capture_stop_client.h"
+#include "disk_buffer_ring.h"
+#include "fake_usb_device.h"
+#include "logger.h"
+#include "synthetic_source.h"
+
+namespace ddd::gui {
+namespace {
+
+using namespace std::chrono_literals;
+
+// --- The protocol ---------------------------------------------------------
+//
+// No socket, no server and no event loop: the wording of a request and the
+// reading of a reply are arithmetic, and everything below tests them as such.
+
+TEST(CaptureControlProtocolTest, ARequestSaysWhatItWants) {
+  const QString line = FormatControlRequest(QLatin1String(kStopVerb));
+
+  EXPECT_TRUE(line.endsWith(QLatin1Char('\n')));
+  EXPECT_EQ(ParseControlVerb(line.toUtf8()).value_or(QString()),
+            QLatin1String(kStopVerb));
+}
+
+// The reason this is JSON rather than a word and a path with a space between
+// them. A capture is named after a disc, and discs have commas, spaces and
+// accents in their titles.
+TEST(CaptureControlProtocolTest, ANameWithPunctuationInItSurvives) {
+  const QString path =
+      QStringLiteral("/captures/Bram Stoker's Dracula, Side 2 (café).ddd.flac");
+
+  const ControlReply reply =
+      ParseControlReply(FormatControlReplyStopped(path, 4096).toUtf8())
+          .value_or(ControlReply{});
+
+  EXPECT_TRUE(reply.ok);
+  EXPECT_EQ(reply.file_path, path);
+  EXPECT_EQ(reply.bytes, 4096U);
+}
+
+// A capture is tens of gigabytes, which is past what a 32-bit count holds.
+TEST(CaptureControlProtocolTest, ALargeCaptureIsCountedProperly) {
+  constexpr quint64 kBytes = quint64{40} << 30;
+
+  const ControlReply reply =
+      ParseControlReply(FormatControlReplyStopped(
+                            QStringLiteral("/captures/a.ddd.flac"), kBytes)
+                            .toUtf8())
+          .value_or(ControlReply{});
+
+  EXPECT_EQ(reply.bytes, kBytes);
+}
+
+TEST(CaptureControlProtocolTest, ARefusalCarriesItsReason) {
+  const ControlReply reply =
+      ParseControlReply(
+          FormatControlReplyError(QStringLiteral("No capture is running."))
+              .toUtf8())
+          .value_or(ControlReply{});
+
+  EXPECT_FALSE(reply.ok);
+  EXPECT_EQ(reply.error, QStringLiteral("No capture is running."));
+}
+
+// A line that cannot be read at all is a different answer from one that says
+// no, and the two must not be confused: the first means the connection is not
+// talking this protocol, the second is this protocol working.
+TEST(CaptureControlProtocolTest, SomethingThatIsNotAMessageIsNotOne) {
+  EXPECT_FALSE(ParseControlVerb(QByteArrayLiteral("hello")).has_value());
+  EXPECT_FALSE(ParseControlVerb(QByteArrayLiteral("[1,2,3]")).has_value());
+  EXPECT_FALSE(
+      ParseControlVerb(QByteArrayLiteral("{\"verb\":\"\"}")).has_value());
+  EXPECT_FALSE(ParseControlVerb(QByteArrayLiteral("{\"verb\":7}")).has_value());
+  EXPECT_FALSE(ParseControlReply(QByteArrayLiteral("{}")).has_value());
+  EXPECT_FALSE(ParseControlReply(QByteArrayLiteral("nonsense")).has_value());
+}
+
+// --- The socket -----------------------------------------------------------
+
+constexpr size_t kTestSlotBytes = size_t{256} << 10;
+constexpr size_t kTestSlotCount = 6;
+
+capture::SyntheticSource::Options TestSourceOptions() {
+  capture::SyntheticSource::Options options;
+  options.slot_size_bytes = kTestSlotBytes;
+  options.slot_count = kTestSlotCount;
+  return options;
+}
+
+template <typename Predicate>
+bool PumpUntil(Predicate predicate, std::chrono::milliseconds limit = 5000ms) {
+  const auto deadline = std::chrono::steady_clock::now() + limit;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
+    std::this_thread::sleep_for(1ms);
+  }
+  return predicate();
+}
+
+// Let the event loop run for a moment, for the cases where what is being
+// checked is that nothing happened yet.
+void PumpFor(std::chrono::milliseconds duration) {
+  PumpUntil([] { return false; }, duration);
+}
+
+class CaptureControlServerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const ::testing::TestInfo* const info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    const QString test_name = QLatin1String(info->name());
+
+    QCoreApplication::setOrganizationName(QStringLiteral("Domesday86Test"));
+    QCoreApplication::setApplicationName(
+        QStringLiteral("ddd-gui-control-%1").arg(test_name));
+    QSettings().clear();
+
+    // A socket of this test's own. CTest runs discovered tests as separate
+    // processes and may run several at once, so a shared name would have one
+    // test connecting to another's server — and none of them may go anywhere
+    // near the socket a real application on this machine is listening on.
+    name_ = QStringLiteral("ddd-gui-control-test-%1").arg(test_name);
+
+    directory_ = std::filesystem::temp_directory_path() /
+                 (std::string("ddd-control-test-") + info->name());
+    std::filesystem::remove_all(directory_);
+    std::filesystem::create_directories(directory_);
+
+    device_ = std::make_unique<capture::FakeUsbDevice>();
+    device_->SetSourceOptions(TestSourceOptions());
+    device_->SetSingleDevice("bus-1", capture::DeviceSpeed::kSuper,
+                             "Domesday Duplicator (a1b2c3d4)");
+
+    controller_ = std::make_unique<CaptureController>(device_.get(), &logger_);
+
+    CaptureSettings settings = controller_->settings();
+    settings.queue_size_bytes = capture::DiskBufferRing::kMinimumQueueSizeBytes;
+    settings.preferred_device_path = QStringLiteral("bus-1");
+    settings.capture_directory = QString::fromStdString(directory_.string());
+    settings.compression_level = 0;
+    controller_->ApplySessionSettings(settings);
+
+    server_ =
+        std::make_unique<CaptureControlServer>(controller_.get(), &logger_);
+  }
+
+  void TearDown() override {
+    // The server borrows the controller, so it goes first.
+    server_.reset();
+    controller_.reset();
+    device_.reset();
+    std::filesystem::remove_all(directory_);
+    QSettings().clear();
+  }
+
+  void Listen() {
+    QString error;
+    ASSERT_TRUE(server_->Listen(name_, &error)) << error.toStdString();
+  }
+
+  struct Run {
+    int code = -1;
+    QString out;
+    QString error;
+  };
+
+  Run Stop(int reply_timeout_milliseconds = 10000) {
+    Run run;
+    QTextStream out(&run.out);
+    QTextStream error(&run.error);
+
+    StopCaptureOptions options;
+    options.server_name = name_;
+    options.connect_timeout_milliseconds = 2000;
+    options.reply_timeout_milliseconds = reply_timeout_milliseconds;
+
+    run.code = RunStopCapture(out, error, options);
+    out.flush();
+    error.flush();
+    return run;
+  }
+
+  // Send a raw line and read whatever comes back, for the cases a well-behaved
+  // client would never produce.
+  QByteArray Exchange(const QByteArray& request) {
+    QLocalSocket socket;
+    socket.connectToServer(name_);
+    if (!PumpUntil([&socket] {
+          return socket.state() == QLocalSocket::ConnectedState;
+        })) {
+      return {};
+    }
+
+    socket.write(request);
+    socket.flush();
+
+    QByteArray buffer;
+    PumpUntil([&socket, &buffer] {
+      buffer.append(socket.readAll());
+      return buffer.contains('\n');
+    });
+    return buffer;
+  }
+
+  std::vector<std::filesystem::path> WrittenFiles() const {
+    std::vector<std::filesystem::path> files;
+    for (const auto& entry : std::filesystem::directory_iterator(directory_)) {
+      if (!capture::MatchedCaptureFileSuffix(entry.path().string()).empty()) {
+        files.push_back(entry.path());
+      }
+    }
+    std::sort(files.begin(), files.end());
+    return files;
+  }
+
+  bool ASidecarWasWritten() const {
+    for (const auto& entry : std::filesystem::directory_iterator(directory_)) {
+      if (entry.path().extension() == ".yaml") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  QString name_;
+  std::filesystem::path directory_;
+  std::unique_ptr<capture::FakeUsbDevice> device_;
+
+  capture::CallbackLogger logger_{
+      [](capture::LogLevel /*level*/, const std::string& /*message*/) {},
+      capture::LogLevel::kDebug};
+
+  std::unique_ptr<CaptureController> controller_;
+  std::unique_ptr<CaptureControlServer> server_;
+};
+
+// --- Listening, and what it means -----------------------------------------
+
+TEST_F(CaptureControlServerTest, ListeningIsTheSingleInstanceCheck) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+  EXPECT_TRUE(server_->listening());
+  EXPECT_EQ(server_->name(), name_);
+
+  // Two processes streaming from one device is not something either of them can
+  // do. The second is told so here, before it has opened anything, rather than
+  // finding out by racing for the USB claim.
+  CaptureControlServer second(controller_.get(), &logger_);
+  QString error;
+  EXPECT_FALSE(second.Listen(name_, &error));
+  EXPECT_TRUE(error.contains(QStringLiteral("already running")))
+      << error.toStdString();
+  EXPECT_FALSE(second.listening());
+}
+
+// The application every user actually runs looks for one name, and it must not
+// be one another user's session is already sitting on.
+TEST_F(CaptureControlServerTest, TheRealNameIsPerUser) {
+  const QString user = qEnvironmentVariable("USER");
+  if (user.isEmpty()) {
+    GTEST_SKIP() << "No USER in the environment to name a socket after.";
+  }
+
+  EXPECT_TRUE(CaptureControlServer::ServerName().contains(user));
+}
+
+#ifndef Q_OS_WIN
+
+// An application that was killed leaves its socket behind. Treating that as a
+// running instance would mean a machine that could not capture again until
+// somebody found and deleted a file they have no reason to know about.
+TEST_F(CaptureControlServerTest, ASocketLeftBehindIsRecoveredFrom) {
+  QString path;
+  {
+    QLocalServer finder;
+    ASSERT_TRUE(finder.listen(name_));
+    path = finder.fullServerName();
+    finder.close();
+  }
+  ASSERT_FALSE(path.isEmpty());
+
+  {
+    QFile remains(path);
+    ASSERT_TRUE(remains.open(QIODevice::WriteOnly));
+    remains.write("what a killed application leaves");
+  }
+  ASSERT_TRUE(QFile::exists(path));
+
+  QString error;
+  EXPECT_TRUE(server_->Listen(name_, &error)) << error.toStdString();
+  EXPECT_TRUE(server_->listening());
+}
+
+#endif  // Q_OS_WIN
+
+// --- Stopping -------------------------------------------------------------
+
+TEST_F(CaptureControlServerTest, WithNothingRunningThereIsNothingToStop) {
+  const Run run = Stop();
+
+  EXPECT_EQ(run.code, kExitNoRunningInstance);
+  EXPECT_TRUE(run.out.isEmpty()) << run.out.toStdString();
+  EXPECT_TRUE(run.error.contains(QStringLiteral("no Domesday Duplicator")))
+      << run.error.toStdString();
+}
+
+// Running, but not capturing. A different answer from the one above, and worth
+// being a different one: the application is there, and a script that gets this
+// has stopped something twice or never started it.
+TEST_F(CaptureControlServerTest, AnApplicationWithNoCaptureSaysSo) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  const Run run = Stop();
+
+  EXPECT_EQ(run.code, kExitCaptureFailed);
+  EXPECT_TRUE(run.out.isEmpty()) << run.out.toStdString();
+  EXPECT_TRUE(run.error.contains(QStringLiteral("No capture is running")))
+      << run.error.toStdString();
+}
+
+// The whole point of the feature. What comes back is the file as it ended up on
+// disk — closed, renamed if the naming asked for a duration, and with its
+// sidecar beside it — because a script that stops a capture reads the file
+// next.
+TEST_F(CaptureControlServerTest, StoppingAnswersWithTheFinishedFile) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  controller_->StartCapture();
+  ASSERT_TRUE(PumpUntil([this] {
+    return !WrittenFiles().empty() &&
+           std::filesystem::file_size(WrittenFiles().front()) > 0;
+  }));
+
+  const Run run = Stop();
+
+  EXPECT_EQ(run.code, kExitSuccess) << run.error.toStdString();
+  EXPECT_FALSE(controller_->capturing());
+
+  // Bare, on its own line, so that a script can use it as it stands.
+  const QString path = run.out.trimmed();
+  ASSERT_FALSE(path.isEmpty()) << run.error.toStdString();
+  EXPECT_TRUE(std::filesystem::exists(path.toStdString()))
+      << path.toStdString();
+
+  // Finished, not merely stopped. The sidecar is written after the file is
+  // closed, so its being here is what proves the client waited for the right
+  // signal rather than for the writer being detached.
+  EXPECT_TRUE(ASidecarWasWritten());
+
+  // The commentary goes to the other stream, where it cannot end up in
+  // whatever the script collected.
+  EXPECT_TRUE(run.error.contains(QStringLiteral("bytes written")))
+      << run.error.toStdString();
+}
+
+// Stopping returns to monitoring rather than to idle, which is what makes
+// several captures from one setup session possible. Stopping twice is therefore
+// an ordinary mistake to make, and it is answered rather than hung on.
+TEST_F(CaptureControlServerTest, StoppingTwiceIsRefusedTheSecondTime) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  controller_->StartCapture();
+  ASSERT_TRUE(PumpUntil([this] {
+    return !WrittenFiles().empty() &&
+           std::filesystem::file_size(WrittenFiles().front()) > 0;
+  }));
+
+  ASSERT_EQ(Stop().code, kExitSuccess);
+
+  const Run again = Stop();
+  EXPECT_EQ(again.code, kExitCaptureFailed);
+  EXPECT_TRUE(again.error.contains(QStringLiteral("No capture is running")))
+      << again.error.toStdString();
+}
+
+// --- Connections that do not behave ---------------------------------------
+
+TEST_F(CaptureControlServerTest, AnUnknownRequestIsAnsweredRatherThanIgnored) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  const ControlReply reply =
+      ParseControlReply(Exchange(QByteArrayLiteral("{\"verb\":\"fly\"}\n")))
+          .value_or(ControlReply{});
+
+  EXPECT_FALSE(reply.ok);
+  EXPECT_TRUE(reply.error.contains(QStringLiteral("fly")))
+      << reply.error.toStdString();
+}
+
+TEST_F(CaptureControlServerTest, SomethingThatIsNotARequestIsAnsweredToo) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  const ControlReply reply =
+      ParseControlReply(Exchange(QByteArrayLiteral("hello?\n")))
+          .value_or(ControlReply{});
+
+  EXPECT_FALSE(reply.ok);
+  EXPECT_FALSE(reply.error.isEmpty());
+}
+
+// A request is one short line and almost always arrives in one piece. Almost
+// always is not something a protocol may be written against.
+TEST_F(CaptureControlServerTest,
+       ARequestSplitAcrossTwoWritesIsStillOneRequest) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  QLocalSocket socket;
+  socket.connectToServer(name_);
+  ASSERT_TRUE(PumpUntil(
+      [&socket] { return socket.state() == QLocalSocket::ConnectedState; }));
+
+  socket.write(QByteArrayLiteral("{\"verb\":\"st"));
+  socket.flush();
+  PumpFor(20ms);
+
+  socket.write(QByteArrayLiteral("op\"}\n"));
+  socket.flush();
+
+  QByteArray buffer;
+  ASSERT_TRUE(PumpUntil([&socket, &buffer] {
+    buffer.append(socket.readAll());
+    return buffer.contains('\n');
+  }));
+
+  // Nothing is capturing, so the answer is the refusal — which is the proof
+  // that the two halves were read as one request rather than as two bad ones.
+  const ControlReply reply = ParseControlReply(buffer).value_or(ControlReply{});
+  EXPECT_FALSE(reply.ok);
+  EXPECT_TRUE(reply.error.contains(QStringLiteral("No capture is running")))
+      << reply.error.toStdString();
+}
+
+// A socket that accepts and then says nothing — an application wedged, or one
+// that died between accepting and answering. The client has to give up rather
+// than hold a script open for ever.
+TEST_F(CaptureControlServerTest, AnApplicationThatNeverAnswersIsGivenUpOn) {
+  QLocalServer silent;
+  ASSERT_TRUE(silent.listen(name_));
+
+  const Run run = Stop(300);
+
+  EXPECT_EQ(run.code, kExitCaptureFailed);
+  EXPECT_TRUE(run.out.isEmpty()) << run.out.toStdString();
+  EXPECT_FALSE(run.error.isEmpty());
+}
+
+}  // namespace
+}  // namespace ddd::gui

--- a/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
@@ -13,10 +13,12 @@
 
 #include <QByteArray>
 #include <QCoreApplication>
+#include <QDir>
 #include <QFile>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QString>
 #include <QTextStream>
 #include <algorithm>
@@ -289,16 +291,75 @@ TEST_F(CaptureControlServerTest, ListeningIsTheSingleInstanceCheck) {
   EXPECT_FALSE(second.listening());
 }
 
+// A second instance is refused, and refusing means leaving the first one
+// alone. The recovery that removes a socket nobody is answering on runs a step
+// away from here, and a version of it that ran against a live application
+// would look exactly like success until somebody tried to stop a capture and
+// reached the wrong process.
+TEST_F(CaptureControlServerTest,
+       ARefusedSecondInstanceLeavesTheFirstReachable) {
+  ASSERT_NO_FATAL_FAILURE(Listen());
+
+  {
+    CaptureControlServer second(controller_.get(), &logger_);
+    QString error;
+    ASSERT_FALSE(second.Listen(name_, &error));
+  }
+
+  EXPECT_TRUE(server_->listening());
+
+  // Answered by the first server, which is the assertion: a client that
+  // reached nothing would be told there was no application at all.
+  const Run run = Stop();
+  EXPECT_EQ(run.code, kExitCaptureFailed);
+  EXPECT_TRUE(run.error.contains(QStringLiteral("No capture is running")))
+      << run.error.toStdString();
+}
+
 // The application every user actually runs looks for one name, and it must not
 // be one another user's session is already sitting on.
 TEST_F(CaptureControlServerTest, TheRealNameIsPerUser) {
+  // The variable each platform sets, in the order ServerName() prefers them.
+  // A Windows shell that came with a Unix toolchain sets both.
+#ifdef Q_OS_WIN
+  const QString user = qEnvironmentVariable("USERNAME");
+  const char* const variable = "USERNAME";
+#else
   const QString user = qEnvironmentVariable("USER");
+  const char* const variable = "USER";
+#endif
   if (user.isEmpty()) {
-    GTEST_SKIP() << "No USER in the environment to name a socket after.";
+    GTEST_SKIP() << "No " << variable << " in the environment to name a socket "
+                 << "after.";
   }
 
   EXPECT_TRUE(CaptureControlServer::ServerName().contains(user));
 }
+
+#ifndef Q_OS_WIN
+
+// The name is a path, and the path is not the temporary directory.
+//
+// A bare name puts the socket under TMPDIR, which a development shell, a
+// systemd unit with PrivateTmp and a build sandbox all set to somewhere of
+// their own. An application started in one of those and a --stop-capture run
+// from an ordinary shell would then be looking in two places, and the script
+// would be told nothing was running while a capture went on in front of it.
+TEST_F(CaptureControlServerTest,
+       TheRealNameDoesNotFollowTheTemporaryDirectory) {
+  const QString runtime =
+      QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
+  if (runtime.isEmpty()) {
+    GTEST_SKIP() << "This session has no runtime directory to put a socket in.";
+  }
+
+  const QString name = CaptureControlServer::ServerName();
+  EXPECT_TRUE(QDir::isAbsolutePath(name)) << name.toStdString();
+  EXPECT_TRUE(name.startsWith(runtime + QLatin1Char('/')))
+      << name.toStdString() << " is not in " << runtime.toStdString();
+}
+
+#endif  // Q_OS_WIN
 
 #ifndef Q_OS_WIN
 

--- a/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
@@ -480,5 +480,42 @@ TEST_F(CaptureControlServerTest, AnApplicationThatNeverAnswersIsGivenUpOn) {
   EXPECT_FALSE(run.error.isEmpty());
 }
 
+// An answer followed immediately by the far end going away, which is not an
+// edge case but the ordinary shape of a successful stop: a headless run exits
+// as soon as the capture it was asked to stop has finished, so the socket it
+// answered on closes in the same turn of the event loop as the answer.
+//
+// The client must take the answer and ignore what happens afterwards. Quitting
+// its loop does not stop the handlers for the rest of the socket's life from
+// running, so without this it printed a success and then, underneath it, a
+// failure about the same stop.
+TEST_F(CaptureControlServerTest, AnApplicationThatQuitsAfterAnsweringIsFine) {
+  const QString path = QStringLiteral("/captures/finished.ddd.flac");
+
+  QLocalServer departing;
+  ASSERT_TRUE(departing.listen(name_));
+  QObject::connect(&departing, &QLocalServer::newConnection, &departing, [&] {
+    QLocalSocket* const socket = departing.nextPendingConnection();
+    if (socket == nullptr) {
+      return;
+    }
+    QObject::connect(socket, &QLocalSocket::readyRead, socket, [socket, path] {
+      socket->readAll();
+      socket->write(FormatControlReplyStopped(path, 4096).toUtf8());
+      socket->flush();
+
+      // And then it is gone, exactly as the process would be.
+      socket->disconnectFromServer();
+    });
+  });
+
+  const Run run = Stop();
+
+  EXPECT_EQ(run.code, kExitSuccess);
+  EXPECT_EQ(run.out.trimmed(), path);
+  EXPECT_FALSE(run.error.contains(QStringLiteral("Error:")))
+      << run.error.toStdString();
+}
+
 }  // namespace
 }  // namespace ddd::gui

--- a/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_control_server.cpp
@@ -158,7 +158,21 @@ class CaptureControlServerTest : public ::testing::Test {
     // processes and may run several at once, so a shared name would have one
     // test connecting to another's server — and none of them may go anywhere
     // near the socket a real application on this machine is listening on.
-    name_ = QStringLiteral("ddd-gui-control-test-%1").arg(test_name);
+    //
+    // Named after the process rather than after the test, because the name has
+    // a length budget and the test names here spend it. A bare name is created
+    // inside QDir::tempPath(), and the whole path has to fit in sun_path: 108
+    // bytes on Linux and 104 on macOS, where the temporary directory is a
+    // per-user /var/folders path of about fifty characters to begin with.
+    // Beyond that listen() fails with a name error rather than with anything
+    // that reads like a length. The process id is what makes the name unique
+    // between concurrent test processes; the counter separates the tests
+    // within one, for a run of the binary directly rather than through CTest.
+    static int sequence = 0;
+    ++sequence;
+    name_ = QStringLiteral("ddd-ctl-%1-%2")
+                .arg(QCoreApplication::applicationPid())
+                .arg(sequence);
 
     directory_ = std::filesystem::temp_directory_path() /
                  (std::string("ddd-control-test-") + info->name());

--- a/ddd-gui/tests/gui/unit/test_capture_controller.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_controller.cpp
@@ -23,6 +23,7 @@
 
 #include "capture_controller.h"
 #include "capture_format.h"
+#include "capture_settings.h"
 #include "fake_usb_device.h"
 #include "firmware_version.h"
 #include "synthetic_source.h"
@@ -573,6 +574,58 @@ TEST_F(CaptureControllerTest, StartingTwiceDoesNotOpenTheDeviceTwice) {
 TEST_F(CaptureControllerTest, StoppingWhenNotMonitoringIsHarmless) {
   controller_->StopMonitoring();
   EXPECT_FALSE(controller_->monitoring());
+}
+
+// --- Settings that belong to one run -------------------------------------
+
+// What the command line names applies to the run it was given to. A script that
+// captures one disc at 20 Msps has not asked for every capture afterwards to be
+// taken at 20 Msps, and SetSettings() would have made that the user's new saved
+// answer — which they would discover the next time they opened the window.
+TEST_F(CaptureControllerTest, SessionSettingsAreNotSaved) {
+  CaptureSettings settings = controller_->settings();
+  settings.capture_name = QStringLiteral("from-the-command-line");
+  settings.decimation_factor = capture::kTapeDecimationFactor;
+
+  controller_->ApplySessionSettings(settings);
+
+  EXPECT_EQ(controller_->settings().capture_name,
+            QStringLiteral("from-the-command-line"));
+  EXPECT_EQ(controller_->settings().decimation_factor,
+            capture::kTapeDecimationFactor);
+
+  // The saved answer is what it was. This fixture points QSettings at a file of
+  // its own and clears it, so a first load is the defaults.
+  const CaptureSettings saved = LoadCaptureSettings();
+  EXPECT_TRUE(saved.capture_name.isEmpty());
+  EXPECT_EQ(saved.decimation_factor, capture::kUndecimatedFactor);
+}
+
+// The panels are told, exactly as they are for a setting the user changed:
+// the window has to show what the capture is going to do, whoever asked for it.
+TEST_F(CaptureControllerTest, SessionSettingsStillReachThePanels) {
+  QSignalSpy changes(controller_.get(), &CaptureController::SettingsChanged);
+
+  CaptureSettings settings = controller_->settings();
+  settings.duration_limit_seconds = 120;
+  controller_->ApplySessionSettings(settings);
+
+  ASSERT_EQ(changes.count(), 1);
+}
+
+// And an edit made afterwards saves in the ordinary way. At that point it is
+// the user's choice rather than the script's, and the panel calls SetSettings()
+// for it like any other.
+TEST_F(CaptureControllerTest, AnEditAfterwardsSavesAsItNormallyWould) {
+  CaptureSettings settings = controller_->settings();
+  settings.capture_name = QStringLiteral("from-the-command-line");
+  controller_->ApplySessionSettings(settings);
+
+  settings.capture_name = QStringLiteral("typed-by-hand");
+  controller_->SetSettings(settings);
+
+  EXPECT_EQ(LoadCaptureSettings().capture_name,
+            QStringLiteral("typed-by-hand"));
 }
 
 TEST_F(CaptureControllerTest, NoBackendAtAllIsReportedRatherThanCrashing) {

--- a/ddd-gui/tests/gui/unit/test_capture_to_disk.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_to_disk.cpp
@@ -944,6 +944,78 @@ TEST_F(CaptureToDiskTest, ASecondCaptureOfTheSameNameIsRenamedAndSaidSo) {
       0U);
 }
 
+// The same guarantee at the other end of the capture, which is where it used to
+// stop holding.
+//
+// A name is resolved before the file is opened, but that is not the name the
+// file ends up with when the naming appends the capture's length: the finished
+// file is renamed, and std::filesystem::rename replaces whatever is at the
+// destination without a word. Two captures of one name that ran for the same
+// length both wanted "<name>_00H00M00S", so the second quietly destroyed the
+// first — after the first had been reported as finished, and with its sidecar
+// going the same way.
+//
+// It is not an unlikely shape. It is what a script produces on every run: one
+// --capture-name, one --duration-limit, the same answer every time.
+TEST_F(CaptureToDiskTest, ADurationRenameNeverLandsOnAnEarlierCapture) {
+  Settings([](CaptureSettings& settings) {
+    settings.capture_name = QStringLiteral("Casper side 1");
+    settings.naming.append_duration = true;
+  });
+
+  QSignalSpy renamed(controller_.get(), &CaptureController::CaptureRenamed);
+
+  const auto capture_once = [this] {
+    controller_->StartCapture();
+    ASSERT_TRUE(controller_->capturing());
+
+    // Waited on by name rather than by taking one off the listing: while the
+    // second capture is open the first one's finished file is in there too,
+    // and it already has contents.
+    const std::filesystem::path live(controller_->capture_path().toStdString());
+    ASSERT_TRUE(PumpUntil([&live] {
+      std::error_code error;
+      const auto size = std::filesystem::file_size(live, error);
+      return !error && size > 0;
+    }));
+
+    controller_->StopCapture();
+    ASSERT_TRUE(PumpUntil([this] { return !controller_->capturing(); }));
+  };
+
+  ASSERT_NO_FATAL_FAILURE(capture_once());
+  ASSERT_TRUE(PumpUntil([&] { return MetadataFiles().size() == 1U; }));
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+
+  const std::filesystem::path first = WrittenFiles().front();
+  const auto first_size = std::filesystem::file_size(first);
+  ASSERT_GT(first_size, 0U);
+
+  // Both captures are stopped the moment anything has reached the file, and the
+  // duration in the name is samples over the sample rate rather than elapsed
+  // time — so a slow machine makes these shorter and never longer. Both are
+  // under a second whatever happens, which is what makes them collide.
+  ASSERT_NE(first.filename().string().find("_00H00M00S"), std::string::npos)
+      << first.filename().string();
+
+  ASSERT_NO_FATAL_FAILURE(capture_once());
+  ASSERT_TRUE(PumpUntil([&] { return MetadataFiles().size() == 2U; }));
+  controller_->StopMonitoring();
+
+  // Two recordings and two sidecars. This was one of each.
+  ASSERT_EQ(WrittenFiles().size(), 2U);
+  EXPECT_TRUE(std::filesystem::exists(first));
+  EXPECT_EQ(std::filesystem::file_size(first), first_size);
+
+  // And it was said out loud, exactly as a collision found before the file is
+  // opened is said out loud.
+  ASSERT_EQ(renamed.count(), 1);
+  EXPECT_EQ(renamed.front().at(0).toString(),
+            QStringLiteral("Casper side 1_00H00M00S"));
+  EXPECT_EQ(renamed.front().at(1).toString(),
+            QStringLiteral("Casper side 1_00H00M00S (1)"));
+}
+
 TEST_F(CaptureToDiskTest, TheGeneratedNameIsNeverReportedAsRenamed) {
   ASSERT_TRUE(controller_->settings().capture_name.isEmpty());
 

--- a/ddd-gui/tests/gui/unit/test_capture_to_disk.cpp
+++ b/ddd-gui/tests/gui/unit/test_capture_to_disk.cpp
@@ -965,19 +965,37 @@ TEST_F(CaptureToDiskTest, ADurationRenameNeverLandsOnAnEarlierCapture) {
 
   QSignalSpy renamed(controller_.get(), &CaptureController::CaptureRenamed);
 
-  const auto capture_once = [this] {
+  // The samples the run has recorded so far, read from the statistics rather
+  // than from the size of the open file on disk.
+  //
+  // This wait is what decides the name, so it has to be short: the duration is
+  // samples over the sample rate, and both captures have to come in under a
+  // second for them to collide at all. The statistics are a counter in memory
+  // published every 50 ms, whereas a live file's size is only as fresh as the
+  // platform makes it — on Windows the directory entry is not updated while
+  // the handle is open, so waiting for it to grow ran for most of a second and
+  // named the capture 00H00M01S, with the second one landing somewhere else.
+  //
+  // Connected through a receiver of its own, declared after the counter and so
+  // destroyed before it: the lambda writes to a local, and an assertion that
+  // ends this test early must not leave it connected to a controller that goes
+  // on publishing into a variable that is no longer there.
+  uint64_t samples = 0;
+  QObject tap;
+  QObject::connect(controller_.get(), &CaptureController::StatsUpdated, &tap,
+                   [&samples](const capture::CaptureStats& stats) {
+                     samples = stats.samples_written;
+                   });
+
+  const auto capture_once = [this, &samples] {
+    samples = 0;
     controller_->StartCapture();
     ASSERT_TRUE(controller_->capturing());
 
-    // Waited on by name rather than by taking one off the listing: while the
-    // second capture is open the first one's finished file is in there too,
-    // and it already has contents.
-    const std::filesystem::path live(controller_->capture_path().toStdString());
-    ASSERT_TRUE(PumpUntil([&live] {
-      std::error_code error;
-      const auto size = std::filesystem::file_size(live, error);
-      return !error && size > 0;
-    }));
+    // Something has to have reached the file before it is stopped, or the
+    // assertion at the end of this test proves nothing — and a capture of no
+    // samples has no duration to append and would never be renamed at all.
+    ASSERT_TRUE(PumpUntil([&samples] { return samples > 0; }));
 
     controller_->StopCapture();
     ASSERT_TRUE(PumpUntil([this] { return !controller_->capturing(); }));
@@ -991,10 +1009,12 @@ TEST_F(CaptureToDiskTest, ADurationRenameNeverLandsOnAnEarlierCapture) {
   const auto first_size = std::filesystem::file_size(first);
   ASSERT_GT(first_size, 0U);
 
-  // Both captures are stopped the moment anything has reached the file, and the
-  // duration in the name is samples over the sample rate rather than elapsed
-  // time — so a slow machine makes these shorter and never longer. Both are
-  // under a second whatever happens, which is what makes them collide.
+  // Both captures are stopped on the first statistics tick that shows a sample,
+  // which is fifty milliseconds of recording and change. The duration in the
+  // name is samples over the sample rate, so that is a name of 00H00M00S with
+  // an order of magnitude to spare even where the synthetic source outruns the
+  // clock — and it is the same name both times, which is what makes them
+  // collide.
   ASSERT_NE(first.filename().string().find("_00H00M00S"), std::string::npos)
       << first.filename().string();
 

--- a/ddd-gui/tests/gui/unit/test_headless_capture_runner.cpp
+++ b/ddd-gui/tests/gui/unit/test_headless_capture_runner.cpp
@@ -1,0 +1,502 @@
+/************************************************************************
+
+    test_headless_capture_runner.cpp
+
+    T1 tests for a capture with no window around it
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QSettings>
+#include <QSignalSpy>
+#include <QString>
+#include <QStringList>
+#include <QTextStream>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "capture_cli.h"
+#include "capture_control_server.h"
+#include "capture_controller.h"
+#include "capture_format.h"
+#include "capture_metadata.h"
+#include "capture_stop_client.h"
+#include "disk_buffer_ring.h"
+#include "fake_usb_device.h"
+#include "headless_capture_runner.h"
+#include "logger.h"
+#include "sample_format.h"
+#include "synthetic_source.h"
+
+namespace ddd::gui {
+namespace {
+
+using namespace std::chrono_literals;
+
+constexpr size_t kTestSlotBytes = size_t{256} << 10;
+constexpr size_t kTestSlotCount = 6;
+
+capture::SyntheticSource::Options TestSourceOptions() {
+  capture::SyntheticSource::Options options;
+  options.slot_size_bytes = kTestSlotBytes;
+  options.slot_count = kTestSlotCount;
+  return options;
+}
+
+template <typename Predicate>
+bool PumpUntil(Predicate predicate, std::chrono::milliseconds limit = 15000ms) {
+  const auto deadline = std::chrono::steady_clock::now() + limit;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
+    std::this_thread::sleep_for(1ms);
+  }
+  return predicate();
+}
+
+class HeadlessCaptureRunnerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const ::testing::TestInfo* const info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    const QString test_name = QLatin1String(info->name());
+
+    QCoreApplication::setOrganizationName(QStringLiteral("Domesday86Test"));
+    QCoreApplication::setApplicationName(
+        QStringLiteral("ddd-gui-headless-%1").arg(test_name));
+    QSettings().clear();
+
+    socket_name_ = QStringLiteral("ddd-gui-headless-test-%1").arg(test_name);
+
+    directory_ = std::filesystem::temp_directory_path() /
+                 (std::string("ddd-headless-test-") + info->name());
+    std::filesystem::remove_all(directory_);
+    std::filesystem::create_directories(directory_);
+
+    device_ = std::make_unique<capture::FakeUsbDevice>();
+    device_->SetSourceOptions(TestSourceOptions());
+    device_->SetSingleDevice("bus-1", capture::DeviceSpeed::kSuper,
+                             "Domesday Duplicator (a1b2c3d4)");
+
+    controller_ = std::make_unique<CaptureController>(device_.get(), &logger_);
+
+    CaptureSettings settings = controller_->settings();
+    settings.queue_size_bytes = capture::DiskBufferRing::kMinimumQueueSizeBytes;
+    settings.preferred_device_path = QStringLiteral("bus-1");
+    settings.capture_directory = QString::fromStdString(directory_.string());
+    settings.compression_level = 0;
+
+    // Applied rather than set, so that nothing here writes into the settings
+    // file — which is what a headless run does with what a command line gave
+    // it, and so is also how this test should arrange one.
+    controller_->ApplySessionSettings(settings);
+  }
+
+  void TearDown() override {
+    finished_.reset();
+    runner_.reset();
+    server_.reset();
+    controller_.reset();
+    device_.reset();
+    std::filesystem::remove_all(directory_);
+    QSettings().clear();
+  }
+
+  static HeadlessCaptureOptions DefaultOptions() {
+    HeadlessCaptureOptions options;
+    options.device_wait_milliseconds = 5000;
+    options.finish_wait_milliseconds = 20000;
+    return options;
+  }
+
+  // Build the runner and start it, in the order a headless run does it: the
+  // runner is connected before the controller starts looking, because the first
+  // device report is the one that starts the capture.
+  HeadlessCaptureRunner& Begin(
+      HeadlessCaptureOptions options = DefaultOptions()) {
+    runner_ = std::make_unique<HeadlessCaptureRunner>(
+        controller_.get(), out_stream_, error_stream_, options);
+    finished_ = std::make_unique<QSignalSpy>(runner_.get(),
+                                             &HeadlessCaptureRunner::Finished);
+    runner_->Begin();
+    controller_->Start();
+    return *runner_;
+  }
+
+  bool WaitForExit() {
+    return PumpUntil([this] { return finished_->count() >= 1; });
+  }
+
+  int ExitCode() const {
+    return finished_->count() >= 1 ? finished_->front().at(0).toInt() : -1;
+  }
+
+  QString Out() {
+    out_stream_.flush();
+    return out_text_;
+  }
+
+  QString Said() {
+    error_stream_.flush();
+    return error_text_;
+  }
+
+  void Change(void (*change)(CaptureSettings&)) {
+    CaptureSettings settings = controller_->settings();
+    change(settings);
+    controller_->ApplySessionSettings(settings);
+  }
+
+  std::vector<std::filesystem::path> WrittenFiles() const {
+    std::vector<std::filesystem::path> files;
+    for (const auto& entry : std::filesystem::directory_iterator(directory_)) {
+      if (!capture::MatchedCaptureFileSuffix(entry.path().string()).empty()) {
+        files.push_back(entry.path());
+      }
+    }
+    return files;
+  }
+
+  // Wait until a capture is being written and has something in it, so that a
+  // test which stops one is stopping a capture rather than racing its start.
+  bool CapturingForReal() {
+    return PumpUntil([this] {
+      return controller_->capturing() && !WrittenFiles().empty() &&
+             std::filesystem::file_size(WrittenFiles().front()) > 0;
+    });
+  }
+
+  QString socket_name_;
+  std::filesystem::path directory_;
+  std::unique_ptr<capture::FakeUsbDevice> device_;
+
+  // A logger that keeps nothing, and given rather than left null so that the
+  // controller's own logging runs on every path here. A line that only exists
+  // where nothing exercises it is a line that can crash a release and pass CI.
+  capture::CallbackLogger logger_{
+      [](capture::LogLevel /*level*/, const std::string& /*message*/) {},
+      capture::LogLevel::kDebug};
+
+  std::unique_ptr<CaptureController> controller_;
+  std::unique_ptr<CaptureControlServer> server_;
+
+  QString out_text_;
+  QString error_text_;
+  QTextStream out_stream_{&out_text_};
+  QTextStream error_stream_{&error_text_};
+
+  std::unique_ptr<HeadlessCaptureRunner> runner_;
+  std::unique_ptr<QSignalSpy> finished_;
+};
+
+// --- A run that goes the way it is meant to -------------------------------
+
+// The unattended capture: nobody presses anything, the limit ends it, and the
+// process exits with a file on disk and its path on standard output.
+TEST_F(HeadlessCaptureRunnerTest, ADurationLimitEndsTheRunByItself) {
+  // Paced at the device's real rate, so that one second of capture is one
+  // second rather than however much an unpaced source managed before the limit
+  // was noticed.
+  capture::SyntheticSource::Options options = TestSourceOptions();
+  options.rate_bytes_per_second = capture::kWireBytesPerSecond;
+  device_->SetSourceOptions(options);
+
+  Change(
+      [](CaptureSettings& settings) { settings.duration_limit_seconds = 1; });
+
+  Begin();
+  ASSERT_TRUE(WaitForExit());
+  EXPECT_EQ(ExitCode(), kExitSuccess);
+
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+  const std::filesystem::path written = WrittenFiles().front();
+  EXPECT_GT(std::filesystem::file_size(written), 0U);
+
+  // The path on stdout is the path of the file that is there, and it is the
+  // only thing on stdout. A script reads that line and opens what it names.
+  EXPECT_EQ(Out(),
+            QString::fromStdString(written.string()) + QLatin1Char('\n'));
+
+  // And the file is finished rather than merely closed: the sidecar is written
+  // after the capture stops, so its being there is the proof that the run
+  // waited for the end rather than exiting when the writer detached.
+  EXPECT_TRUE(std::filesystem::exists(capture::CaptureMetadataPath(written)));
+}
+
+TEST_F(HeadlessCaptureRunnerTest, WhatAPersonReadsGoesToTheOtherStream) {
+  Begin();
+  ASSERT_TRUE(CapturingForReal());
+
+  runner_->RequestStop();
+  ASSERT_TRUE(WaitForExit());
+  ASSERT_EQ(ExitCode(), kExitSuccess);
+
+  const QString said = Said();
+  EXPECT_TRUE(said.contains(QStringLiteral("Capturing to ")))
+      << said.toStdString();
+  EXPECT_TRUE(said.contains(QStringLiteral("Finished."))) << said.toStdString();
+
+  // One line, and it is a path. Everything else went to the stream a script
+  // does not read.
+  EXPECT_EQ(Out().trimmed().split(QLatin1Char('\n')).size(), 1);
+}
+
+// --- Stopping -------------------------------------------------------------
+
+// Ctrl+C, and the whole reason SignalWatcher exists: the capture is stopped
+// politely and the file is finished before the process is allowed to end.
+TEST_F(HeadlessCaptureRunnerTest,
+       AnInterruptFinishesTheFileRatherThanCuttingIt) {
+  Begin();
+  ASSERT_TRUE(CapturingForReal());
+
+  runner_->RequestStop();
+
+  ASSERT_TRUE(WaitForExit());
+  EXPECT_EQ(ExitCode(), kExitSuccess);
+
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+  const std::filesystem::path written = WrittenFiles().front();
+  EXPECT_TRUE(std::filesystem::exists(capture::CaptureMetadataPath(written)));
+  EXPECT_EQ(Out(),
+            QString::fromStdString(written.string()) + QLatin1Char('\n'));
+}
+
+// A second interrupt while the encoder is closing the file. It is the moment a
+// user is most likely to press Ctrl+C again, and the one where doing what they
+// asked would cost them the capture.
+TEST_F(HeadlessCaptureRunnerTest, InterruptingAgainDoesNotAbandonTheFile) {
+  Begin();
+  ASSERT_TRUE(CapturingForReal());
+
+  runner_->RequestStop();
+  runner_->RequestStop();
+
+  ASSERT_TRUE(WaitForExit());
+  EXPECT_EQ(ExitCode(), kExitSuccess);
+
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+  EXPECT_TRUE(std::filesystem::exists(
+      capture::CaptureMetadataPath(WrittenFiles().front())));
+  EXPECT_TRUE(Said().contains(QStringLiteral("Still finishing")))
+      << Said().toStdString();
+}
+
+// The Windows stop, and the one a script uses everywhere: another process asks
+// over the control socket. The runner is not told about it and does not need to
+// be — it sees the capture stop and waits for the file, exactly as it does for
+// an interrupt.
+TEST_F(HeadlessCaptureRunnerTest, AStopFromASecondProcessEndsTheRun) {
+  Begin();
+  ASSERT_TRUE(CapturingForReal());
+
+  server_ = std::make_unique<CaptureControlServer>(controller_.get(), &logger_);
+  QString listen_error;
+  ASSERT_TRUE(server_->Listen(socket_name_, &listen_error))
+      << listen_error.toStdString();
+
+  QString client_out_text;
+  QString client_error_text;
+  QTextStream client_out(&client_out_text);
+  QTextStream client_error(&client_error_text);
+
+  StopCaptureOptions options;
+  options.server_name = socket_name_;
+  options.connect_timeout_milliseconds = 2000;
+  options.reply_timeout_milliseconds = 20000;
+
+  EXPECT_EQ(RunStopCapture(client_out, client_error, options), kExitSuccess);
+  client_out.flush();
+
+  ASSERT_TRUE(WaitForExit());
+  EXPECT_EQ(ExitCode(), kExitSuccess);
+
+  // Both halves name the same file: the one the client was told about and the
+  // one the run itself printed. A script may read either.
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+  EXPECT_EQ(client_out_text.trimmed(),
+            QString::fromStdString(WrittenFiles().front().string()));
+  EXPECT_EQ(Out().trimmed(), client_out_text.trimmed());
+}
+
+// --- Nothing to capture from ----------------------------------------------
+
+TEST_F(HeadlessCaptureRunnerTest, NothingPluggedInIsItsOwnExitCode) {
+  device_->SetDevices({});
+
+  HeadlessCaptureOptions options = DefaultOptions();
+  options.device_wait_milliseconds = 500;
+
+  Begin(options);
+  ASSERT_TRUE(WaitForExit());
+
+  EXPECT_EQ(ExitCode(), kExitNoDevice);
+  EXPECT_TRUE(WrittenFiles().empty());
+  EXPECT_TRUE(Out().isEmpty()) << Out().toStdString();
+  EXPECT_TRUE(
+      Said().contains(QStringLiteral("No Domesday Duplicator was found")))
+      << Said().toStdString();
+}
+
+// Interrupted while still waiting. Nothing was captured and there is no file,
+// which is the same thing the exit code above says — so it says the same thing.
+TEST_F(HeadlessCaptureRunnerTest, AnInterruptBeforeADeviceCapturesNothing) {
+  device_->SetDevices({});
+
+  Begin();
+
+  // After a device report has been and gone, so this is an interrupt during the
+  // wait rather than one that raced the runner's own start.
+  QSignalSpy devices(controller_.get(), &CaptureController::DevicesChanged);
+  ASSERT_TRUE(PumpUntil([&devices] { return devices.count() >= 1; }));
+
+  runner_->RequestStop();
+  ASSERT_TRUE(WaitForExit());
+
+  EXPECT_EQ(ExitCode(), kExitNoDevice);
+  EXPECT_TRUE(WrittenFiles().empty());
+  EXPECT_TRUE(Out().isEmpty()) << Out().toStdString();
+}
+
+// --- Failures -------------------------------------------------------------
+
+// The ordering that makes an exit code worth reading. When a run fails
+// mid-capture the controller reports the finished file first and the failure
+// second, in the same call — so a runner that exited on the first of them would
+// tell a script that a broken capture went perfectly well.
+TEST_F(HeadlessCaptureRunnerTest, AFailedRunSaysSoEvenThoughAFileWasWritten) {
+  capture::SyntheticSource::Options options = TestSourceOptions();
+  options.fault = capture::SyntheticSource::Fault::kTransferFailure;
+  options.fault_at_slot = 12;
+  device_->SetSourceOptions(options);
+
+  Begin();
+  ASSERT_TRUE(WaitForExit());
+
+  EXPECT_EQ(ExitCode(), kExitCaptureFailed);
+  EXPECT_TRUE(Said().contains(QStringLiteral("Error:")))
+      << Said().toStdString();
+
+  // And the file it did write is still named, because it is still there and
+  // still readable. A failure is a reason to go and look at a capture, not a
+  // reason to be told nothing about it.
+  ASSERT_EQ(WrittenFiles().size(), 1U);
+  EXPECT_EQ(Out().trimmed(),
+            QString::fromStdString(WrittenFiles().front().string()));
+}
+
+// A capture that never opened a file at all. There is nothing to wait for, so
+// the run ends at once rather than sitting out the finish timeout.
+TEST_F(HeadlessCaptureRunnerTest, ACaptureThatCannotBeOpenedEndsAtOnce) {
+  const std::filesystem::path blocker = directory_ / "a-regular-file";
+  {
+    const std::ofstream file(blocker);
+    ASSERT_TRUE(file.good());
+  }
+
+  CaptureSettings settings = controller_->settings();
+  settings.capture_directory =
+      QString::fromStdString((blocker / "not-a-directory").string());
+  controller_->ApplySessionSettings(settings);
+
+  Begin();
+  ASSERT_TRUE(WaitForExit());
+
+  EXPECT_EQ(ExitCode(), kExitCaptureFailed);
+  EXPECT_TRUE(Out().isEmpty()) << Out().toStdString();
+  EXPECT_TRUE(Said().contains(QStringLiteral("Error:")))
+      << Said().toStdString();
+}
+
+// --- The windowed half of --start-capture ---------------------------------
+
+TEST_F(HeadlessCaptureRunnerTest, TheWindowedStartWaitsForTheDeviceToArrive) {
+  device_->SetDevices({});
+
+  StartCaptureWhenDeviceAppears(controller_.get());
+  controller_->Start();
+
+  // An empty report first, and it must not spend the watch. It is what the
+  // monitor produces on its first poll with nothing attached, so a one-shot
+  // connection would be used up on it and the capture would never start.
+  QSignalSpy devices(controller_.get(), &CaptureController::DevicesChanged);
+  ASSERT_TRUE(PumpUntil([&devices] { return devices.count() >= 1; }));
+  EXPECT_FALSE(controller_->capturing());
+
+  device_->SetSingleDevice("bus-1", capture::DeviceSpeed::kSuper,
+                           "Domesday Duplicator (a1b2c3d4)");
+
+  ASSERT_TRUE(PumpUntil([this] { return controller_->capturing(); }));
+
+  controller_->StopCapture();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->capturing(); }));
+  controller_->StopMonitoring();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->monitoring(); }));
+}
+
+TEST_F(HeadlessCaptureRunnerTest, AWindowedStartWithADeviceAlreadyThereIsNow) {
+  controller_->Start();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->devices().empty(); }));
+
+  StartCaptureWhenDeviceAppears(controller_.get());
+  EXPECT_TRUE(controller_->capturing());
+
+  controller_->StopCapture();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->capturing(); }));
+  controller_->StopMonitoring();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->monitoring(); }));
+}
+
+// It starts one capture and then lets go. A watch that stayed connected would
+// take the next device report as another instruction to capture, and a user who
+// unplugged the Duplicator to move it would come back to a second recording
+// nobody asked for.
+//
+// Checked after the session has ended rather than during it: the controller
+// suspends the device monitor for as long as the stream is open — opening a
+// device to enumerate it underneath a running transfer is exactly what that
+// suspension exists to prevent — so a mid-capture report is not a thing that
+// happens. The reports resume when monitoring stops, which is where the watch
+// would show itself if it were still there.
+TEST_F(HeadlessCaptureRunnerTest, TheWindowedStartOnlyEverStartsOneCapture) {
+  device_->SetDevices({});
+
+  StartCaptureWhenDeviceAppears(controller_.get());
+  controller_->Start();
+
+  device_->SetSingleDevice("bus-1", capture::DeviceSpeed::kSuper,
+                           "Domesday Duplicator (a1b2c3d4)");
+  ASSERT_TRUE(PumpUntil([this] { return controller_->capturing(); }));
+
+  controller_->StopCapture();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->capturing(); }));
+  controller_->StopMonitoring();
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->monitoring(); }));
+
+  // The device goes and comes back, which is two more reports — and the second
+  // of them looks exactly like the one that started the capture above.
+  device_->SetDevices({});
+  ASSERT_TRUE(PumpUntil([this] { return controller_->devices().empty(); }));
+  device_->SetSingleDevice("bus-1", capture::DeviceSpeed::kSuper,
+                           "Domesday Duplicator (a1b2c3d4)");
+  ASSERT_TRUE(PumpUntil([this] { return !controller_->devices().empty(); }));
+
+  EXPECT_FALSE(controller_->capturing());
+  EXPECT_EQ(WrittenFiles().size(), 1U);
+}
+
+}  // namespace
+}  // namespace ddd::gui

--- a/ddd-gui/tests/gui/unit/test_headless_capture_runner.cpp
+++ b/ddd-gui/tests/gui/unit/test_headless_capture_runner.cpp
@@ -79,7 +79,16 @@ class HeadlessCaptureRunnerTest : public ::testing::Test {
         QStringLiteral("ddd-gui-headless-%1").arg(test_name));
     QSettings().clear();
 
-    socket_name_ = QStringLiteral("ddd-gui-headless-test-%1").arg(test_name);
+    // Named after the process rather than after the test: the whole path has
+    // to fit in sun_path, and a bare name goes inside QDir::tempPath(), which
+    // on macOS is a per-user /var/folders path with fifty characters gone
+    // before the name starts. See the same construction in
+    // test_capture_control_server.cpp.
+    static int sequence = 0;
+    ++sequence;
+    socket_name_ = QStringLiteral("ddd-hls-%1-%2")
+                       .arg(QCoreApplication::applicationPid())
+                       .arg(sequence);
 
     directory_ = std::filesystem::temp_directory_path() /
                  (std::string("ddd-headless-test-") + info->name());

--- a/ddd-gui/tests/gui/unit/test_signal_watcher.cpp
+++ b/ddd-gui/tests/gui/unit/test_signal_watcher.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>
+#include <QMetaObject>
 #include <QSignalSpy>
 #include <chrono>
 #include <thread>
@@ -46,11 +47,66 @@ bool PumpUntil(Predicate predicate, std::chrono::milliseconds limit = 2000ms) {
 
 #ifdef Q_OS_WIN
 
-// Nothing to install, and saying so is the contract: main() has to be able to
-// carry on without a watcher rather than treating its absence as a failure.
-TEST(SignalWatcherTest, ThereIsNothingToInstallHere) {
+// What can be tested here and what cannot.
+//
+// The delivery is testable: the console handler's whole job is to post to the
+// watcher from another thread, and a test can post the same way and prove the
+// interrupt comes out on the event loop rather than wherever it arrived.
+//
+// The arrival is not. A console control event is sent to a whole process
+// group, and this test runs in the group CTest is running in — raising a real
+// Ctrl+C here would interrupt the test runner along with everything beside it.
+// That half is covered by the manual pass on Windows.
+class SignalWatcherTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    watcher_ = SignalWatcher::Install();
+    ASSERT_NE(watcher_, nullptr);
+  }
+
+  void TearDown() override {
+    delete watcher_;
+    watcher_ = nullptr;
+  }
+
+  // The one thing the console handler does, from a thread of its own as it
+  // does it.
+  void PostFromAnotherThread() {
+    std::thread([this] {
+      QMetaObject::invokeMethod(watcher_, "Deliver", Qt::QueuedConnection);
+    }).join();
+  }
+
+  SignalWatcher* watcher_ = nullptr;
+};
+
+TEST_F(SignalWatcherTest, AnInterruptArrivesOnTheEventLoop) {
+  QSignalSpy interrupts(watcher_, &SignalWatcher::Interrupted);
+
+  PostFromAnotherThread();
+
+  // Nothing yet: the point of the posting is that the interrupt waits for the
+  // loop rather than running on whatever thread Windows delivered it on.
+  EXPECT_EQ(interrupts.count(), 0);
+
+  EXPECT_TRUE(PumpUntil([&interrupts] { return interrupts.count() == 1; }));
+  EXPECT_EQ(interrupts.count(), 1);
+}
+
+TEST_F(SignalWatcherTest, ThereIsOnlyEverOneOfThem) {
+  EXPECT_TRUE(SignalWatcher::installed());
   EXPECT_EQ(SignalWatcher::Install(), nullptr);
+}
+
+TEST_F(SignalWatcherTest, DestroyingItUninstallsIt) {
+  delete watcher_;
+  watcher_ = nullptr;
+
   EXPECT_FALSE(SignalWatcher::installed());
+
+  SignalWatcher* replacement = SignalWatcher::Install();
+  EXPECT_NE(replacement, nullptr);
+  delete replacement;
 }
 
 #else

--- a/ddd-gui/tests/gui/unit/test_signal_watcher.cpp
+++ b/ddd-gui/tests/gui/unit/test_signal_watcher.cpp
@@ -1,0 +1,140 @@
+/************************************************************************
+
+    test_signal_watcher.cpp
+
+    T1 tests for turning an interrupt into an event-loop signal
+    Domesday Duplicator - LaserDisc RF sampler
+    SPDX-FileCopyrightText: 2026 Simon Inns
+    SPDX-License-Identifier: GPL-3.0-or-later
+
+************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <chrono>
+#include <thread>
+
+#include "signal_watcher.h"
+
+#ifndef Q_OS_WIN
+#include <csignal>
+#endif
+
+namespace ddd::gui {
+namespace {
+
+using namespace std::chrono_literals;
+
+// Pump the event loop until a condition holds, so a test fails with a message
+// rather than hanging. The whole point of this class is that the interrupt is
+// delivered later, on the loop, so there is nothing to block on.
+template <typename Predicate>
+bool PumpUntil(Predicate predicate, std::chrono::milliseconds limit = 2000ms) {
+  const auto deadline = std::chrono::steady_clock::now() + limit;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
+    std::this_thread::sleep_for(1ms);
+  }
+  return predicate();
+}
+
+#ifdef Q_OS_WIN
+
+// Nothing to install, and saying so is the contract: main() has to be able to
+// carry on without a watcher rather than treating its absence as a failure.
+TEST(SignalWatcherTest, ThereIsNothingToInstallHere) {
+  EXPECT_EQ(SignalWatcher::Install(), nullptr);
+  EXPECT_FALSE(SignalWatcher::installed());
+}
+
+#else
+
+class SignalWatcherTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    watcher_ = SignalWatcher::Install();
+    ASSERT_NE(watcher_, nullptr);
+  }
+
+  // Deleted rather than left to the process, so that the next test starts with
+  // the default disposition and a raise() here cannot reach a watcher that
+  // belonged to a test that has finished.
+  void TearDown() override {
+    delete watcher_;
+    watcher_ = nullptr;
+  }
+
+  SignalWatcher* watcher_ = nullptr;
+};
+
+// The assertion that matters. Raising it proves the process was not ended by
+// it, which is the default disposition and the thing that would leave a capture
+// file unfinished; the spy proves it arrived somewhere the capture can be
+// stopped properly.
+TEST_F(SignalWatcherTest, AnInterruptArrivesOnTheEventLoop) {
+  QSignalSpy interrupts(watcher_, &SignalWatcher::Interrupted);
+
+  ASSERT_EQ(::raise(SIGINT), 0);
+
+  EXPECT_TRUE(PumpUntil([&interrupts] { return interrupts.count() == 1; }));
+  EXPECT_EQ(interrupts.count(), 1);
+}
+
+// kill(1) sends this one, and it is what a script uses rather than Ctrl+C.
+TEST_F(SignalWatcherTest, ATerminationRequestArrivesTheSameWay) {
+  QSignalSpy interrupts(watcher_, &SignalWatcher::Interrupted);
+
+  ASSERT_EQ(::raise(SIGTERM), 0);
+
+  EXPECT_TRUE(PumpUntil([&interrupts] { return interrupts.count() == 1; }));
+  EXPECT_EQ(interrupts.count(), 1);
+}
+
+// A user pressing Ctrl+C twice because the first one looked like it did nothing
+// is asking for the same thing twice, not for something else. Both arrive
+// before the loop is pumped, and one request comes out.
+TEST_F(SignalWatcherTest, TwoInterruptsTogetherAreOneRequest) {
+  QSignalSpy interrupts(watcher_, &SignalWatcher::Interrupted);
+
+  ASSERT_EQ(::raise(SIGINT), 0);
+  ASSERT_EQ(::raise(SIGINT), 0);
+
+  EXPECT_TRUE(PumpUntil([&interrupts] { return interrupts.count() >= 1; }));
+
+  // Pump a little longer, so a second delivery would have somewhere to land if
+  // one were coming.
+  PumpUntil([] { return false; }, 50ms);
+  EXPECT_EQ(interrupts.count(), 1);
+}
+
+// The handler reaches one descriptor, held in a file-scope variable because a
+// signal handler is handed no context of its own. A second watcher would take
+// that descriptor away from the first, so there is no second watcher.
+TEST_F(SignalWatcherTest, ThereIsOnlyEverOneOfThem) {
+  EXPECT_TRUE(SignalWatcher::installed());
+  EXPECT_EQ(SignalWatcher::Install(), nullptr);
+}
+
+TEST_F(SignalWatcherTest, DestroyingItUninstallsIt) {
+  delete watcher_;
+  watcher_ = nullptr;
+
+  EXPECT_FALSE(SignalWatcher::installed());
+
+  // And the seat is free, which is what proves the descriptor and the handler
+  // were both let go rather than merely forgotten.
+  SignalWatcher* replacement = SignalWatcher::Install();
+  EXPECT_NE(replacement, nullptr);
+  delete replacement;
+}
+
+#endif  // Q_OS_WIN
+
+}  // namespace
+}  // namespace ddd::gui

--- a/ddd-gui/tests/gui/widget/test_capture_panel.cpp
+++ b/ddd-gui/tests/gui/widget/test_capture_panel.cpp
@@ -14,6 +14,7 @@
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QCommandLineParser>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -21,6 +22,7 @@
 #include <QSettings>
 #include <QSignalSpy>
 #include <QSpinBox>
+#include <QStringList>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -29,6 +31,7 @@
 #include <thread>
 #include <vector>
 
+#include "capture_cli.h"
 #include "capture_controller.h"
 #include "capture_format.h"
 #include "capture_panel.h"
@@ -945,6 +948,56 @@ TEST_F(CapturePanelTest, TheNamingButtonAsksForItsDialogRatherThanOpeningOne) {
 
   NamingButton()->click();
   EXPECT_EQ(asked.count(), 1);
+}
+
+// The other half of --start-capture: attributes given on the command line with
+// no start command simply set the window up, so that somebody can check what a
+// script would have done and then press the button themselves.
+//
+// Driven from an actual command line rather than from a settings struct,
+// because the chain is the thing being tested — the argument, the parse, the
+// override, the session apply, and the control a user reads it off.
+TEST_F(CapturePanelTest, WhatTheCommandLineNamedIsWhatThePanelOpensShowing) {
+  const QString directory = QString::fromStdString(
+      (std::filesystem::temp_directory_path() / "ddd-panel-test-cli-directory")
+          .string());
+
+  QCommandLineParser parser;
+  const CaptureCliOptionSet options = AddCaptureCliOptions(parser);
+  ASSERT_TRUE(parser.parse(QStringList{
+      QStringLiteral("ddd-gui"), QStringLiteral("--capture-directory"),
+      directory, QStringLiteral("--capture-name"),
+      QStringLiteral("Casper side 1"), QStringLiteral("--sample-rate"),
+      QStringLiteral("20"), QStringLiteral("--duration-limit"),
+      QStringLiteral("300"), QStringLiteral("--output-format"),
+      QStringLiteral("s16")}))
+      << parser.errorText().toStdString();
+
+  const CaptureCliParseResult parsed = ParseCaptureCliOptions(parser, options);
+  ASSERT_TRUE(parsed.ok()) << parsed.error.toStdString();
+
+  CaptureSettings settings = controller_->settings();
+  ApplyCliOverrides(settings, parsed.options);
+  controller_->ApplySessionSettings(settings);
+
+  // Rebuilt afterwards, as the window's panel is: CapturePanel reads the
+  // controller's settings in its constructor, so this is the case where the
+  // panel has to be born populated rather than told later.
+  panel_ = std::make_unique<CapturePanel>(controller_.get());
+
+  EXPECT_EQ(NameEdit()->text(), QStringLiteral("Casper side 1"));
+  EXPECT_EQ(SampleRateCombo()->currentData().toInt(),
+            capture::kTapeDecimationFactor);
+  EXPECT_EQ(FormatCombo()->currentData().toInt(),
+            static_cast<int>(capture::CaptureOutputFormat::kSigned16Bit));
+
+  // The panel offers minutes where the command line takes seconds, so five
+  // minutes is what three hundred seconds shows as.
+  EXPECT_EQ(DurationSpin()->value(), 5);
+
+  // Not on the panel — it lives in File ▸ Settings… — so it is checked where it
+  // landed rather than not checked at all.
+  EXPECT_EQ(controller_->settings().capture_directory, directory);
 }
 
 }  // namespace

--- a/docs/content/capture-gui/.nav.yml
+++ b/docs/content/capture-gui/.nav.yml
@@ -20,3 +20,4 @@ nav:
   - If an update fails: if-an-update-fails.md
   - If a capture fails: if-a-capture-fails.md
   - Command line: command-line.md
+  - Scripting captures: scripting.md

--- a/docs/content/capture-gui/capture-control.md
+++ b/docs/content/capture-gui/capture-control.md
@@ -40,6 +40,12 @@ names the capture from what it found, takes the side, and reports what was writt
 way into that window rather than a mode the panel enters: the format and sample rate below
 are the same settings the workflow's own second page shows, and the two cannot disagree.
 
+Both buttons have a command-line equivalent, for when something other than a person has to
+press them — an audio recording that must start at the same moment, or a capture nobody is
+going to be in the room for. A capture started from a script can be stopped from this panel
+and one started here can be stopped from a script; they are the same capture either way. See
+[Scripting captures](scripting.md).
+
 ## Where the device and the folder went
 
 Both are on the **Capture** tab of **File ▸ Settings…** rather than on this panel. Neither

--- a/docs/content/capture-gui/command-line.md
+++ b/docs/content/capture-gui/command-line.md
@@ -114,6 +114,35 @@ to the panel and the console and says so.
     verdict from standard output does not have to filter them out. On Windows the console is
     the one the application was started from, as described under `--version` above.
 
+### Capture options
+
+Eight options start, stop and set up a capture, so that a script can do what the window
+does. They are listed here for completeness and covered properly — with the exit codes, the
+worked examples and what each platform needs — in
+**[Scripting captures](scripting.md)**.
+
+| Option | What it does |
+| --- | --- |
+| `--start-capture` | Start capturing as soon as a device is found. The window still opens unless `--headless` is given |
+| `--headless` | Run with no window. Needs `--start-capture` |
+| `--stop-capture` | Stop the capture a running instance is taking, wait for its file to be finished, print it and exit |
+| `--capture-directory <folder>` | Write here instead of the configured folder. Created if it is not there |
+| `--capture-name <name>` | Call the capture this, without a suffix |
+| `--sample-rate <msps>` | `40` or `20` |
+| `--duration-limit <seconds>` | 1 to 86400. Leave it out to capture until stopped |
+| `--output-format <format>` | `flac` or `s16` |
+
+Given without `--start-capture` or `--stop-capture`, the last five simply fill the window in
+and start nothing. Whatever they set applies to that run only and is never saved.
+
+```bash
+ddd-gui --headless --start-capture --capture-name disc-42-side-1 --duration-limit 1800
+```
+
+The finished file's path goes to standard output on its own, and everything meant for a
+person goes to standard error — so `file=$(ddd-gui --headless --start-capture …)` is all the
+parsing a script needs.
+
 ### `--analyse-test-data <file>`
 
 Check a test-mode capture for sequence breaks and exit, without opening a window.

--- a/docs/content/capture-gui/index.md
+++ b/docs/content/capture-gui/index.md
@@ -45,6 +45,7 @@ what each one is for.
 | [Test mode](test-mode.md) | Proving the capture path with the gateware's test pattern |
 | [Updating your Duplicator](updating-your-domesday-duplicator.md) | Installing firmware and gateware into the device |
 | [Command line](command-line.md) | The options the application accepts, and the scriptable analysis |
+| [Scripting captures](scripting.md) | Starting and stopping a capture from a script, with no window if you want none — and starting an audio recording at the same moment |
 
 ## Getting the device programmed, and what to do when something is wrong
 
@@ -91,6 +92,10 @@ to put it, the run, and what happened — examining the disc, naming the capture
 found, driving the player through the side, and stopping both at the end. **Capture another side**
 on the last page turns the whole thing round for the other side of the disc. It is the path
 for working through a stack of them.
+
+Either can be started **from a script** instead of by hand, with the window or without one —
+which is what to do when something else has to start recording at the same moment, or when
+nobody is going to be in the room. See [Scripting captures](scripting.md).
 
 ## What it writes
 

--- a/docs/content/capture-gui/scripting.md
+++ b/docs/content/capture-gui/scripting.md
@@ -1,0 +1,376 @@
+# Scripting captures
+
+The application takes a capture from a script as well as from its window: the same code, the
+same file, the same metadata beside it. What the command line adds is a way to *start* a
+capture at a moment your script chooses, and a way to stop it again from somewhere else.
+
+That is mostly wanted for one thing. If you are recording the analogue audio of a disc with
+another tool while the Duplicator takes the RF, the two recordings have to begin close
+together, and neither of them begins when a person presses a button. A script starts the RF
+capture, waits until it is really running, starts the audio, and stops both at the end.
+
+The other cases are unattended ones: a fixed-length capture with nobody in the room, a
+machine with no display, a rig that takes a side and moves on.
+
+## Three ways to run it
+
+| | What it does |
+| --- | --- |
+| `--start-capture` | Opens the window as usual and starts capturing as soon as a device is found. You watch it and stop it however you like |
+| `--start-capture --headless` | No window at all. Runs until the duration limit, until it is stopped, or until it is interrupted, then prints the finished file and exits |
+| `--stop-capture` | Not a capture at all: a message to an application that is already running. Stops its capture, waits for the file to be finished, prints it, exits |
+
+Given on their own, the attribute options — the folder, the name, the rate, the limit, the
+format — start nothing. They fill the window in, which is the "set this up for me and I will
+press the button myself" case.
+
+| Where the binary is | |
+| --- | --- |
+| Linux (Flatpak) | `flatpak run --command=ddd-gui io.github.simoninns.DddGui` |
+| macOS | `/Applications/Domesday Duplicator.app/Contents/MacOS/ddd-gui` |
+| Windows | `C:\Program Files\Domesday Duplicator\ddd-gui.exe` |
+
+Both packaged platforms need a little more than the path, and neither is obvious from
+outside: see [Running it from a Flatpak](#running-it-from-a-flatpak) and
+[Running it on Windows](#running-it-on-windows) below.
+
+## The options
+
+| Option | What it takes | What it does |
+| --- | --- | --- |
+| `--start-capture` | | Start capturing once a device is found |
+| `--headless` | | No window. Needs `--start-capture` |
+| `--stop-capture` | | Stop the capture a running instance is taking. Cannot be combined with any of the others |
+| `--capture-directory <folder>` | a folder | Write here instead of the configured folder. Created if it is not there |
+| `--capture-name <name>` | a name | Call the capture this, without a suffix |
+| `--sample-rate <msps>` | `40` or `20` | Capture at this rate. The decimation is done by the device |
+| `--duration-limit <seconds>` | 1 to 86400 | Stop by itself after this long. Leave it out to capture until stopped |
+| `--output-format <format>` | `flac` or `s16` | Write [FLAC, or uncompressed `.ddd.s16`](capture-files.md) |
+
+Anything the command line does not mention is left exactly as
+[Settings](settings.md) has it, so a script says what is different about *this* capture and
+nothing else.
+
+### What the command line sets, it does not save
+
+Values given on the command line apply to that run and are then forgotten. Nothing is
+written to your settings, so a scripted capture at 20 Msps into a scratch folder does not
+quietly become what the window opens showing tomorrow.
+
+!!! note "The one way that can bite you"
+
+    Session-only means *the command line never saves anything*. It does not mean the values
+    are kept apart from your settings while the application runs — the window is showing
+    them because they really are the settings this run is using.
+
+    So if you start with `--start-capture --sample-rate 20` and then change something else
+    in the window, what gets saved is what the window is showing, 20 Msps included. That is
+    only reachable with a window in front of you; a `--headless` run saves nothing whatever
+    happens.
+
+### The folder and the name
+
+`--capture-directory` is created if it does not exist, one level or several, exactly as a
+capture started from the window creates it. A path that exists and is not a folder is
+refused before anything opens.
+
+`--capture-name` is a name and not a path — a `/` or a `\` in it is refused rather than
+accepted and then failing much later, when the file is opened. Name the folder with
+`--capture-directory`.
+
+The name you give is a starting point, not the final file name. The
+[naming rules in Settings](capture-naming.md#how-the-file-name-is-built) still apply, so the
+file may end up with [its length appended](capture-naming.md#append-the-captures-length), or
+[a number added](capture-naming.md#if-the-name-is-already-there) if the name was taken. This
+is exactly why the finished path is printed at the end: **read the path, do not construct
+it.**
+
+### The duration limit
+
+In seconds, from 1 to 86400 (24 hours). Zero is refused rather than taken to mean *no
+limit* — a script that worked out a limit of zero has a bug in it, and capturing until
+something else intervened would hide that bug rather than report it.
+
+The window's own field is in whole minutes, so with `--start-capture` and no `--headless` a
+limit that is not a whole number of minutes cannot be shown exactly. The run still uses the
+seconds you gave; it is only the displayed value that rounds.
+
+## What a run prints
+
+**Standard output carries the path of the finished capture, alone, and nothing else.**
+Everything meant for a person watching — what it is capturing to, that it stopped, how many
+bytes were written, anything that went wrong — goes to standard error.
+
+That split is the whole interface. It means a script can do this
+
+```bash
+file=$(ddd-gui --headless --start-capture --duration-limit 60)
+```
+
+and have the path, with no parsing, no filtering and nothing to go wrong when a capture is
+named after a disc with a comma in its title.
+
+The application's own log is separate again, and a headless run is quiet by default. Add
+[`--log-out console`](command-line.md#-log-out-destination) to see it, or
+[`--log-file`](command-line.md#-f-log-file-file) to keep it — that is what to do before
+reporting a fault in a scripted capture.
+
+### What a script may rely on
+
+Three things, and they are meant to be depended on:
+
+- the finished path on **standard output**, on its own line;
+- the **exit code**, from the table below;
+- the line **`Capturing to <path>`** on standard error, which is printed the moment the file
+  is open and is how a script knows the capture is really running.
+
+The rest of what goes to standard error is written for a person and may be reworded.
+
+!!! warning "Use that line as a starting gun, not as a file name"
+
+    The path in `Capturing to` is the file *while it is being written*, and it is often not
+    what the capture ends up called: a name with
+    [its length appended](capture-naming.md#append-the-captures-length) is only given that
+    length once the capture has one, so `disc-42.ddd.flac` becomes
+    `disc-42_00H41M12S.ddd.flac` at the end.
+
+    The path on standard output is the finished file, and it is the one to keep.
+
+## Exit codes
+
+| Code | What happened | What to do about it |
+| --- | --- | --- |
+| `0` | The capture ran and the file was finished | Read the path on standard output |
+| `1` | The command line could not be made sense of | The message on standard error names the option |
+| `2` | Another Domesday Duplicator is already running, or the control socket could not be created | Stop the other one, or wait for it |
+| `3` | No device was found | Nothing was captured. Check the cable and the [device state](if-a-capture-fails.md) |
+| `4` | A capture started and then something went wrong | A file exists. Go and look at it — it is as complete as it could be made |
+| `5` | `--stop-capture` found nothing running to stop | The capture had already stopped, or was never started |
+
+Exit code `3` is reported after a wait of about ten seconds, which is enough for a device
+that is being plugged in as the script starts. A windowed `--start-capture` has no such
+limit — the window is open and can wait indefinitely, because somebody is looking at it.
+
+## Only one at a time
+
+Two processes cannot stream from one Duplicator, so a second `--start-capture` or
+`--headless` run refuses with exit code `2` rather than racing the first one for the device.
+An application that was killed rather than stopped leaves nothing in the way: the socket it
+left behind is recognised as abandoned and cleaned up by the next run.
+
+The exclusion is per user, and it does not reach across packaging: a Flatpak instance and a
+locally built binary do not know about each other, and neither can stop the other.
+
+## Stopping a capture
+
+Every way of stopping ends the same: the stream is detached, the encoder finishes the file,
+the [duration is appended](capture-naming.md#append-the-captures-length) if the naming asks
+for it, and the [metadata file](capture-naming.md#what-the-metadata-file-contains) is written
+beside it. Only then does the process exit and print the path.
+
+| How | Where it works | When to use it |
+| --- | --- | --- |
+| `--duration-limit` | Everywhere | The length is known in advance |
+| `ddd-gui --stop-capture` | Everywhere | Another script, another terminal, another machine's session — anything that is not the capture's own console |
+| Ctrl+C | Everywhere | You are sitting in front of it |
+| `kill` (`SIGINT` or `SIGTERM`) | Linux, macOS | A script that holds the process ID |
+| `CTRL_BREAK_EVENT` | Windows | A script that holds the process ID — see [below](#running-it-on-windows) |
+
+`--stop-capture` waits for the file. It does not return when the capture stops; it returns
+when the capture has been *finished*, and prints the same path the capturing process prints.
+A script can stop a capture and read the file on the next line with nothing in between.
+
+!!! warning "Never `kill -9` a capture"
+
+    `SIGKILL` cannot be caught, so nothing runs: the FLAC stream is left without its final
+    block, no metadata file is written, and what is on disk may not open. Every other way of
+    stopping finishes the file properly. If a capture appears stuck, `--stop-capture` and
+    wait — finishing a large file on a slow disk takes as long as it takes.
+
+Interrupting twice does no harm and does not make it quicker. Once the file is being
+finished, a second interrupt is answered with a line saying as much and otherwise ignored —
+abandoning the file at that point is the one thing that would leave it unreadable.
+
+## Worked examples
+
+### Audio and RF, started together
+
+The case this was built for. The RF capture is the one with a device to open and buffers to
+fill, so it goes first; the audio starts when the RF capture says it is running.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+directory=~/captures/disc-42
+name=disc-42-side-1
+mkdir -p "$directory"
+
+# Start the RF capture. Its path will land in $directory/rf.path when it finishes.
+ddd-gui --headless --start-capture \
+        --capture-directory "$directory" --capture-name "$name" \
+        > "$directory/rf.path" 2> "$directory/rf.log" &
+rf=$!
+
+# Wait until it is really capturing, rather than guessing with a sleep.
+until grep -q '^Capturing to ' "$directory/rf.log"; do
+    if ! kill -0 "$rf" 2>/dev/null; then
+        echo "The RF capture did not start:" >&2
+        cat "$directory/rf.log" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
+# Now the audio, with whatever records it on this machine.
+rec -q -c 2 -r 48000 -b 24 "$directory/$name.wav" &
+audio=$!
+
+read -r -p "Press return when the side has played out... "
+
+kill -INT "$audio"
+ddd-gui --stop-capture > /dev/null
+wait "$rf"
+
+echo "RF:    $(cat "$directory/rf.path")"
+echo "Audio: $directory/$name.wav"
+```
+
+### A fixed-length capture, unattended
+
+Nothing to stop it and nobody watching. The exit code is the whole report.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Taken from the command itself rather than read back after an `if`, where the
+# negation would have replaced it with its own success.
+status=0
+file=$(ddd-gui --headless --start-capture \
+               --capture-directory /captures/disc-42 \
+               --capture-name disc-42-side-1 \
+               --sample-rate 20 \
+               --duration-limit 1800) || status=$?
+
+if (( status != 0 )); then
+    case $status in
+        2) echo "Something else is using the Duplicator." >&2 ;;
+        3) echo "No Duplicator was found." >&2 ;;
+        4) echo "The capture failed part way through." >&2 ;;
+        *) echo "The capture could not be started." >&2 ;;
+    esac
+    exit "$status"
+fi
+
+echo "Captured $file"
+ls -lh "$file" "${file%.ddd.flac}.ddd.yaml"
+```
+
+### Stopping one from somewhere else
+
+Any shell, any script, at any point:
+
+```bash
+ddd-gui --stop-capture
+```
+
+It works whether the capture was started from a script or from the window, because every
+instance listens for it.
+
+## Running it from a Flatpak
+
+Options go after the application ID, and everything above applies unchanged:
+
+```bash
+flatpak run --command=ddd-gui io.github.simoninns.DddGui \
+    --headless --start-capture \
+    --capture-directory ~/captures/disc-42 --capture-name disc-42-side-1 \
+    --duration-limit 1800
+```
+
+Stopping it is the same command with `--stop-capture`, and it reaches the running instance
+because both are the same application:
+
+```bash
+flatpak run --command=ddd-gui io.github.simoninns.DddGui --stop-capture
+```
+
+Two things about a sandbox are worth knowing before you write the script rather than
+afterwards.
+
+!!! warning "`kill` does not reach inside the sandbox"
+
+    A Flatpak application runs inside its own process namespace, and `flatpak run` is not
+    it. Sending `SIGTERM` to the `flatpak run` process ends the sandbox and takes the
+    capture down with it, mid-file — the application never sees the signal and never
+    finishes the file.
+
+    Ctrl+C at a terminal *does* work, because that reaches every process in the group. But
+    a script must stop a Flatpak capture with `--stop-capture`, not with `kill`.
+
+!!! warning "`/tmp` is not the `/tmp` you can see"
+
+    A sandbox has a private `/tmp` of its own, held in memory and invisible from outside it.
+    `--capture-directory /tmp/something` is accepted — the folder does exist, from inside —
+    and then fills your RAM with capture data that no other program can read and that
+    disappears when the application exits.
+
+    Captures belong under your home directory, or on a drive under `/run/media`, `/media` or
+    `/mnt`. Those are the paths the sandbox is given, and they mean the same thing inside it
+    as out.
+
+## Running it on Windows
+
+Two things are different, and both come from the same cause: the application is a windowed
+program, so a command prompt does not wait for it.
+
+**Wait for it explicitly, or you get no exit code.** `ddd-gui.exe` returns to the prompt
+immediately and `%ERRORLEVEL%` means nothing. In PowerShell, which is the easier of the two:
+
+```powershell
+$ddd = "C:\Program Files\Domesday Duplicator\ddd-gui.exe"
+
+$run = Start-Process -FilePath $ddd -Wait -PassThru -NoNewWindow `
+    -ArgumentList '--headless','--start-capture',
+                  '--capture-directory','D:\captures\disc-42',
+                  '--capture-name','disc-42-side-1',
+                  '--duration-limit','1800' `
+    -RedirectStandardOutput 'D:\captures\disc-42\rf.path'
+
+if ($run.ExitCode -ne 0) { throw "The capture failed with $($run.ExitCode)" }
+Get-Content 'D:\captures\disc-42\rf.path'
+```
+
+From `cmd.exe`, `start /wait /b` waits and keeps the current console, so a redirection still
+lands where you put it:
+
+```bat
+set DDD="C:\Program Files\Domesday Duplicator\ddd-gui.exe"
+start /wait /b "" %DDD% --headless --start-capture ^
+    --capture-directory D:\captures\disc-42 --capture-name disc-42-side-1 ^
+    --duration-limit 1800 > D:\captures\disc-42\rf.path
+echo Exit code %ERRORLEVEL%
+```
+
+**The installer does not put it on your `PATH`**, so scripts name it in full. It is
+`C:\Program Files\Domesday Duplicator\ddd-gui.exe` unless you chose a different folder when
+installing.
+
+Stopping works as it does everywhere: `--stop-capture` from another prompt, or Ctrl+C in the
+console the capture is running in, both finish the file properly. A script that holds the
+process ID can send `CTRL_BREAK_EVENT` with `GenerateConsoleCtrlEvent`, which is handled the
+same way. Closing the console window is the one exception — Windows allows a few seconds and
+then ends the process regardless of what it is doing, so a capture stopped that way may be
+left unfinished. Use `--stop-capture`.
+
+## Running it on macOS
+
+The binary is inside the application bundle:
+
+```bash
+/Applications/Domesday\ Duplicator.app/Contents/MacOS/ddd-gui --stop-capture
+```
+
+Everything else is as it is on Linux, signals included. Both commands have to run as the
+same user — the control socket is private to the account that created it.

--- a/docs/content/capture-gui/scripting.md
+++ b/docs/content/capture-gui/scripting.md
@@ -85,6 +85,13 @@ file may end up with [its length appended](capture-naming.md#append-the-captures
 is exactly why the finished path is printed at the end: **read the path, do not construct
 it.**
 
+A script that runs repeatedly with the same `--capture-name` therefore accumulates files
+rather than replacing them — `disc-42_00H30M00S`, then `disc-42_00H30M00S (1)`, and so on,
+with the new name reported on standard error each time. Nothing a capture writes is ever
+written over. If you want one file per run rather than a growing pile, give each run a name
+of its own, or leave `--capture-name` out and take the generated name, which carries a
+timestamp and is unique by construction.
+
 ### The duration limit
 
 In seconds, from 1 to 86400 (24 hours). Zero is refused rather than taken to mean *no


### PR DESCRIPTION
## Summary

Adds command-line capture control to `ddd-gui`, so a capture can be started, stopped and
set up from a script — with a window or without one. This is what issue #165 asks for: the
motivating case is recording a disc's analogue audio with another tool while the Duplicator
takes the RF, where the two recordings have to begin together and neither begins when a
person presses a button. Unattended fixed-length captures and machines with no display come
along with it.

Eight options: `--start-capture`, `--headless`, `--stop-capture`, `--capture-directory`,
`--capture-name`, `--sample-rate`, `--duration-limit`, `--output-format`. Given without a
start command the attribute options simply fill the window in, and nothing any of them sets
is ever written to the settings file.

The application now runs in three modes, chosen before any `Q*Application` exists so that a
headless run never needs a platform plugin. Two things are worth knowing about the design:

- **Stopping happens over a `QLocalServer` control socket**, not a temp file. `ddd-gui
  --stop-capture` asks the running instance to stop and then *waits for the file* — closed,
  duration rename applied, sidecar written — before printing the path and exiting. A script
  can stop a capture and read the file on the next line. Every instance listens, so a
  capture started from a script can be stopped from the window and vice versa.
- **The finished path goes to stdout alone; everything meant for a person goes to stderr.**
  That makes `file=$(ddd-gui --headless --start-capture …)` all the parsing a script needs,
  including for a disc whose title has a comma in it.

Listening doubles as the single-instance check: two processes cannot stream from one
Duplicator, so a second scripted start refuses with exit 2 rather than racing for the USB
claim. Interrupts (SIGINT/SIGTERM, and console control events on Windows) are turned into
an ordinary event-loop signal, so an interrupted capture finishes its file instead of being
truncated.

Exit codes are the interface: `0` success, `1` bad arguments, `2` another instance, `3` no
device, `4` the capture failed, `5` nothing running to stop.

### Two fixes to existing behaviour

Both were found by testing rather than by reading, and neither is in the new code.

**A capture could overwrite another.** The capture path is made unique before the file is
opened, but the naming's *append the capture's length* option renames the finished file
afterwards, and `std::filesystem::rename` replaces its destination without a word. Two
captures of one name that ran for the same length both wanted `<name>_00H30M00S`, so the
second destroyed the first — silently, after the first had been reported as finished, and
taking its sidecar with it. This contradicts a guarantee stated in bold on the *Naming and
metadata* page. It is reachable from the window by typing one name twice, but scripting
makes it the ordinary case: a fixed `--capture-name` with a fixed `--duration-limit`
produces byte-identical final names on every run. The rename now resolves through
`MakeUniqueCapturePath()`, the same helper the open path uses, and reports the new name.

**Windows redirection was hijacked.** `console_attach.cpp` reopened `stdout` and `stderr`
onto `CONOUT$` unconditionally after `AttachConsole`, which takes a redirected stream away
from the file or pipe the caller asked for and puts it on the screen — defeating the whole
stdout contract above. The handles are now sampled with `GetFileType` before attaching, and
a stream the caller redirected is left alone.

### Packaged builds

The implementation was written against a binary run out of the build directory, then checked
against both packaged forms. Three things needed changing:

- **The single-instance check did not work on Windows at all.** Qt creates a `QLocalServer`
  there as a named pipe with `PIPE_UNLIMITED_INSTANCES` and no `FILE_FLAG_FIRST_PIPE_INSTANCE`,
  so a second process listening on a name its neighbour holds *succeeds*, and `setError()`
  reports `UnknownSocketError` rather than the `AddressInUseError` the check was built on.
  Both instances would have believed they were alone, and a stop could have been answered by
  the one that was not capturing. `Listen()` now knocks before it listens on every platform,
  and knocks again before removing anything so the stale-socket recovery cannot delete a live
  application's socket.
- **The socket followed `TMPDIR`.** Qt puts a bare-named local socket in `QDir::tempPath()`,
  so a capture started inside a development shell, a systemd unit with `PrivateTmp` or a
  build sandbox could not be stopped from an ordinary shell — the client reported nothing
  running while a capture went on in front of it. The name is now an absolute path in the
  session runtime directory on Unix.
- **Ctrl+C truncated a headless capture on Windows.** There are no POSIX signals, but
  `AttachParentConsole()` gives the process a console, so it received `CTRL_C_EVENT` and the
  default handler ended it mid-file. `SignalWatcher` now has a Windows half using
  `SetConsoleCtrlHandler`, covering `CTRL_C_EVENT` and the `CTRL_BREAK_EVENT` a script sends
  with `GenerateConsoleCtrlEvent`.

Flatpak needed no manifest change — `Qt6::Network` is in both halves of `org.kde.Platform`
6.11, and the socket is `AF_UNIX` inside the sandbox's own filesystem. Measured rather than
assumed: `/tmp` in a sandbox is keyed on the application, not the instance, so two
`flatpak run` invocations reach each other; and a SIGINT to the process group reaches the
application while `kill -TERM` on the `flatpak run` process does not. Both are documented.

## Component

- [x] Capture application (`ddd-gui`, `ddd-update`, `ddd-jtag`)
- [ ] FX3 firmware (`fx3/firmware`)
- [ ] FX3 programmer (`fx3/programmer`)
- [ ] FPGA gateware (`fpga/`)
- [ ] Hardware / PCB (`hardware/`)
- [x] Documentation (`docs/`)
- [x] Build, packaging or Nix flake
- [ ] Repository tooling (`tools/`)

`Qt6::Network` is added to the Qt components — for `QLocalServer` and `QLocalSocket`, and
for nothing else. The application still makes no network connections.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Validation

**Test suite** — `ctest --test-dir ddd-gui/build -LE hil` → **1859 passing, 0 failing**.
71 new test cases: option parsing and validation, the control protocol and a loopback server,
the stop client against an in-process server, the headless state machine against
`FakeUsbDevice`, signal delivery, and a widget test driving a real argv through to the
Capture panel. Builds clean through the clang-format and clang-tidy gates;
`./tools/check-licence-headers.sh` and `mkdocs build --strict` both pass.

The regression test for the overwrite bug was confirmed to **fail with the fix backed out**,
so it pins the defect rather than merely passing beside it.

**Hardware in the loop** — a 21-capture scenario sweep against an attached Duplicator
(`ID 1209:2347 Generic Domesday Duplicator (4d23a25)`), plus the captures taken to verify
the overwrite fix afterwards:

- 11 malformed command lines rejected with exit 1 and a message naming the option.
- 4 s at 40 Msps → 79.7 MB with the sidecar recording 40 MHz; `--sample-rate 20` recorded
  `decimation_factor: 2`; `--output-format s16` wrote `.ddd.s16`; a 12 s limit measured
  12.032 s; a three-level folder that did not exist was created; a name containing an
  apostrophe, a comma, parentheses and `café` round-tripped through stdout and opened
  directly.
- SIGINT, SIGTERM, `--stop-capture` and the duration limit all exit 0 with a finished file,
  and `flac -t` verifies every one. A burst of 12 interrupts was absorbed with the file still
  valid. A stop 0.25 s in produced a valid 400-byte FLAC with zero samples rather than
  anything corrupt.
- A second headless run and a second windowed `--start-capture` both refused with exit 2
  while a capture was running. Windowed `--start-capture` captured and stayed up after
  `--stop-capture` took its file. `--stop-capture` gives exit 4 against a running-but-idle
  instance and exit 5 against nothing.
- After a run passing `--sample-rate 20 --output-format s16` against saved values of
  `decimation_factor=1` and `output_format=flac`, the settings file was byte-identical and
  its mtime unchanged.
- The overwrite fix reproduced on hardware: three runs with one name and one duration limit
  now produce three files that all decode, each with its own correctly-named sidecar.
- The audio-and-RF worked example from the new documentation page ran verbatim, with a
  stand-in for the audio recorder.

Exit code 3 needs the Duplicator absent and was not exercised on hardware; it is covered by
unit tests. The Windows console handler and the `CONOUT$` guard are the two pieces no test
in this project can reach — a console control event goes to a whole process group, which
under CTest is the test runner — and want a manual pass against the MSI.

- [x] `nix flake check`, or the component's own tests (`ctest --test-dir <component>/build`)
- [x] Hardware-in-the-loop check per [TESTING.md](../TESTING.md) — **required** for gateware,
      FX3 firmware, or anything on the capture path, where a green build is not sufficient

## Checklist

- [x] Scope is focused and minimal
- [x] Build passes locally
- [x] New source files carry the SPDX licence header — `./tools/check-licence-headers.sh`
- [x] Follows the conventions in [AGENTS.md](../AGENTS.md)
- [x] Related docs under [docs/content/](../docs/content/) were updated if needed
- [x] Linked issue (if applicable)

New user documentation: **[Scripting captures](../docs/content/capture-gui/scripting.md)** —
the three ways to run it, the options, the exit codes, every way of stopping, worked
examples, and a section each for Flatpak, Windows and macOS. Linked from the section index
and cross-referenced from *Command line* and *Capture control*.

## Related issue

Closes #165
